### PR TITLE
Use correct english plural for child

### DIFF
--- a/src/ast/any_expr.rs
+++ b/src/ast/any_expr.rs
@@ -159,29 +159,29 @@ macro_rules! impl_expr_kinds {
             }
         }
 
-        impl Childs for AnyExpr {
-            fn childs(&self) -> ChildsIter {
+        impl Children for AnyExpr {
+            fn children(&self) -> ChildrenIter {
 				use self::AnyExpr::*;
 				match *self {
-					$($names(ref expr) => expr.childs()),*
+					$($names(ref expr) => expr.children()),*
                 }
             }
         }
 
-        impl ChildsMut for AnyExpr {
-            fn childs_mut(&mut self) -> ChildsIterMut {
+        impl ChildrenMut for AnyExpr {
+            fn children_mut(&mut self) -> ChildrenIterMut {
 				use self::AnyExpr::*;
 				match *self {
-					$($names(ref mut expr) => expr.childs_mut()),*
+					$($names(ref mut expr) => expr.children_mut()),*
                 }
             }
         }
 
-        impl IntoChilds for AnyExpr {
-            fn into_childs(self) -> IntoChildsIter {
+        impl IntoChildren for AnyExpr {
+            fn into_children(self) -> IntoChildrenIter {
 				use self::AnyExpr::*;
 				match self {
-					$($names(expr) => expr.into_childs()),*
+					$($names(expr) => expr.into_children()),*
                 }
             }
         }

--- a/src/ast/arity.rs
+++ b/src/ast/arity.rs
@@ -24,16 +24,16 @@ pub trait HasArity {
 
     /// Returns `true` if `self` has child expressions.
     #[inline]
-    fn has_childs(&self) -> bool {
+    fn has_children(&self) -> bool {
         self.arity() > 0
     }
 }
 
-/// Returns the accumulated arity of the given entity and all of its childs recursively.
+/// Returns the accumulated arity of the given entity and all of its children recursively.
 /// 
 /// This is used to identify complex expressions with many recursive child expressions.
 pub fn recursive_arity<T>(expr: &T) -> usize
-    where T: HasArity + Childs
+    where T: HasArity + Children
 {
-    expr.arity() + expr.childs().map(|c| recursive_arity(c)).sum::<usize>()
+    expr.arity() + expr.children().map(|c| recursive_arity(c)).sum::<usize>()
 }

--- a/src/ast/binexpr_children.rs
+++ b/src/ast/binexpr_children.rs
@@ -2,7 +2,7 @@ use ast::prelude::*;
 
 pub mod prelude {
     pub use super::{
-        BinExprChilds
+        BinExprChildren
     };
 }
 
@@ -13,26 +13,26 @@ pub mod prelude {
 /// All binary expressions should strive to use this utility to store their
 /// child expressions.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct BinExprChilds {
+pub struct BinExprChildren {
     pub lhs: AnyExpr,
     pub rhs: AnyExpr
 }
 
-impl BinExprChilds {
-    /// Creates a new `BinExprChilds` for the given child expressions.
+impl BinExprChildren {
+    /// Creates a new `BinExprChildren` for the given child expressions.
     #[inline]
-    pub fn new(lhs: AnyExpr, rhs: AnyExpr) -> BinExprChilds {
-        BinExprChilds{lhs, rhs}
+    pub fn new(lhs: AnyExpr, rhs: AnyExpr) -> BinExprChildren {
+        BinExprChildren{lhs, rhs}
     }
 
-    /// Creates a new boxed (on heap) `BinExprChilds` for the given child expressions.
+    /// Creates a new boxed (on heap) `BinExprChildren` for the given child expressions.
     #[inline]
-    pub fn new_boxed(lhs: AnyExpr, rhs: AnyExpr) -> P<BinExprChilds> {
-        P::new(BinExprChilds::new(lhs, rhs))
+    pub fn new_boxed(lhs: AnyExpr, rhs: AnyExpr) -> P<BinExprChildren> {
+        P::new(BinExprChildren::new(lhs, rhs))
     }
 
     /// Swaps its left-hand side child with the right-hand side child.
-    pub fn swap_childs(&mut self) {
+    pub fn swap_children(&mut self) {
         use std::mem;
         mem::swap(&mut self.lhs, &mut self.rhs)
     }
@@ -45,33 +45,33 @@ impl BinExprChilds {
     }
 }
 
-impl Childs for BinExprChilds {
+impl Children for BinExprChildren {
     /// Returns an immutable iterator over the two child expressions.
     #[inline]
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::binary(&self.lhs, &self.rhs)
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::binary(&self.lhs, &self.rhs)
     }
 }
 
-impl ChildsMut for BinExprChilds {
+impl ChildrenMut for BinExprChildren {
     /// Returns an mutable iterator over the two child expressions.
     #[inline]
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::binary(&mut self.lhs, &mut self.rhs)
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::binary(&mut self.lhs, &mut self.rhs)
     }
 }
 
-impl IntoChilds for BinExprChilds {
-    /// Consumes this `BinExprChilds` and returns an iterator over its two child expressions.
+impl IntoChildren for BinExprChildren {
+    /// Consumes this `BinExprChildren` and returns an iterator over its two child expressions.
     /// 
     /// This may be used to transfer ownership of its child expressions.
     #[inline]
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::binary(self.lhs, self.rhs)
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::binary(self.lhs, self.rhs)
     }
 }
 
-impl HasArity for BinExprChilds {
+impl HasArity for BinExprChildren {
     #[inline]
     fn arity(&self) -> usize {
         2

--- a/src/ast/child_iters/child_iter.rs
+++ b/src/ast/child_iters/child_iter.rs
@@ -7,126 +7,126 @@ use std::mem;
 /// Re-exports commonly used items of this module.
 pub mod prelude {
     pub use super::{
-		ChildsIter	
+		ChildrenIter	
 	};
 }
 
 /// Iterator over immutable child expressions.
 #[derive(Debug, Clone)]
-pub enum ChildsIter<'p> {
-    Inl(InlChildsIter<'p>),
-    Ext(ExtChildsIter<'p>)
+pub enum ChildrenIter<'p> {
+    Inl(InlChildrenIter<'p>),
+    Ext(ExtChildrenIter<'p>)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct InlChildsIter<'p> {
-    childs: [Option<&'p AnyExpr>; 3],
+pub struct InlChildrenIter<'p> {
+    children: [Option<&'p AnyExpr>; 3],
     begin: usize,
 	end: usize
 }
 
-impl<'p> InlChildsIter<'p> {
-    fn from_array(num_childs: usize, childs: [Option<&'p AnyExpr>; 3]) -> InlChildsIter {
-        InlChildsIter{childs, begin: 0, end: num_childs.saturating_sub(1)}
+impl<'p> InlChildrenIter<'p> {
+    fn from_array(num_children: usize, children: [Option<&'p AnyExpr>; 3]) -> InlChildrenIter {
+        InlChildrenIter{children, begin: 0, end: num_children.saturating_sub(1)}
     }
 
-    pub fn none() -> InlChildsIter<'p> {
-        InlChildsIter::from_array(0, [None; 3])
+    pub fn none() -> InlChildrenIter<'p> {
+        InlChildrenIter::from_array(0, [None; 3])
     }
 
-	pub fn unary(fst: &'p AnyExpr) -> InlChildsIter<'p> {
-		InlChildsIter::from_array(1, [Some(fst), None, None])
+	pub fn unary(fst: &'p AnyExpr) -> InlChildrenIter<'p> {
+		InlChildrenIter::from_array(1, [Some(fst), None, None])
 	}
 
-	pub fn binary(fst: &'p AnyExpr, snd: &'p AnyExpr) -> InlChildsIter<'p> {
-		InlChildsIter::from_array(2, [Some(fst), Some(snd), None])
+	pub fn binary(fst: &'p AnyExpr, snd: &'p AnyExpr) -> InlChildrenIter<'p> {
+		InlChildrenIter::from_array(2, [Some(fst), Some(snd), None])
 	}
 
-	pub fn ternary(fst: &'p AnyExpr, snd: &'p AnyExpr, trd: &'p AnyExpr) -> InlChildsIter<'p> {
-		InlChildsIter::from_array(3, [Some(fst), Some(snd), Some(trd)])
+	pub fn ternary(fst: &'p AnyExpr, snd: &'p AnyExpr, trd: &'p AnyExpr) -> InlChildrenIter<'p> {
+		InlChildrenIter::from_array(3, [Some(fst), Some(snd), Some(trd)])
 	}
 }
 
-impl<'p> Iterator for InlChildsIter<'p> {
+impl<'p> Iterator for InlChildrenIter<'p> {
     type Item = &'p AnyExpr;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Using replace here is a trick to enable efficient correct
 		// iteration using `Iterator` and `DoubleEndedIterator` so
 		// that no element is yielded twice.
-        let elem = mem::replace(&mut self.childs[self.begin], None);
+        let elem = mem::replace(&mut self.children[self.begin], None);
         self.begin = cmp::min(self.begin + 1, 2);
         elem
     }
 }
 
-impl<'p> DoubleEndedIterator for InlChildsIter<'p> {
+impl<'p> DoubleEndedIterator for InlChildrenIter<'p> {
     fn next_back(&mut self) -> Option<Self::Item> {
         // Using replace here is a trick to enable efficient correct
 		// iteration using `Iterator` and `DoubleEndedIterator` so
 		// that no element is yielded twice.
-        let elem = mem::replace(&mut self.childs[self.end], None);
+        let elem = mem::replace(&mut self.children[self.end], None);
         self.end = self.end.saturating_sub(1);
         elem
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct ExtChildsIter<'p> {
-    childs: slice::Iter<'p, AnyExpr>
+pub struct ExtChildrenIter<'p> {
+    children: slice::Iter<'p, AnyExpr>
 }
 
-impl<'p> ExtChildsIter<'p> {
-    fn from_slice(childs: &'p [AnyExpr]) -> ExtChildsIter {
-        ExtChildsIter{childs: childs.into_iter()}
+impl<'p> ExtChildrenIter<'p> {
+    fn from_slice(children: &'p [AnyExpr]) -> ExtChildrenIter {
+        ExtChildrenIter{children: children.into_iter()}
     }
 }
 
-impl<'p> Iterator for ExtChildsIter<'p> {
+impl<'p> Iterator for ExtChildrenIter<'p> {
     type Item = &'p AnyExpr;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.childs.next()
+        self.children.next()
     }
 }
 
-impl<'p> DoubleEndedIterator for ExtChildsIter<'p> {
+impl<'p> DoubleEndedIterator for ExtChildrenIter<'p> {
 	fn next_back(&mut self) -> Option<Self::Item> {
-		self.childs.next_back()
+		self.children.next_back()
 	}
 }
 
-impl<'p> ChildsIter<'p> {
-	pub fn none() -> ChildsIter<'p> {
-        ChildsIter::Inl(InlChildsIter::none())
+impl<'p> ChildrenIter<'p> {
+	pub fn none() -> ChildrenIter<'p> {
+        ChildrenIter::Inl(InlChildrenIter::none())
 	}
 
-	pub fn unary(fst: &'p AnyExpr) -> ChildsIter<'p> {
-        ChildsIter::Inl(InlChildsIter::unary(fst))
+	pub fn unary(fst: &'p AnyExpr) -> ChildrenIter<'p> {
+        ChildrenIter::Inl(InlChildrenIter::unary(fst))
 	}
 
-	pub fn binary(fst: &'p AnyExpr, snd: &'p AnyExpr) -> ChildsIter<'p> {
-        ChildsIter::Inl(InlChildsIter::binary(fst, snd))
+	pub fn binary(fst: &'p AnyExpr, snd: &'p AnyExpr) -> ChildrenIter<'p> {
+        ChildrenIter::Inl(InlChildrenIter::binary(fst, snd))
 	}
 
 	pub fn ternary(
 		fst: &'p AnyExpr,
 		snd: &'p AnyExpr,
-		trd: &'p AnyExpr) -> ChildsIter<'p>
+		trd: &'p AnyExpr) -> ChildrenIter<'p>
 	{
-		ChildsIter::Inl(InlChildsIter::ternary(fst, snd, trd))
+		ChildrenIter::Inl(InlChildrenIter::ternary(fst, snd, trd))
 	}
 
-	pub fn nary(childs: &'p [AnyExpr]) -> ChildsIter<'p> {
-		ChildsIter::Ext(ExtChildsIter::from_slice(childs))
+	pub fn nary(children: &'p [AnyExpr]) -> ChildrenIter<'p> {
+		ChildrenIter::Ext(ExtChildrenIter::from_slice(children))
 	}
 }
 
-impl<'p> Iterator for ChildsIter<'p> {
+impl<'p> Iterator for ChildrenIter<'p> {
 	type Item = &'p AnyExpr;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		use self::ChildsIter::*;
+		use self::ChildrenIter::*;
 		match *self {
 			Inl(ref mut iter) => iter.next(),
 			Ext(ref mut iter) => iter.next()
@@ -134,9 +134,9 @@ impl<'p> Iterator for ChildsIter<'p> {
 	}
 }
 
-impl<'p> DoubleEndedIterator for ChildsIter<'p> {
+impl<'p> DoubleEndedIterator for ChildrenIter<'p> {
 	fn next_back(&mut self) -> Option<Self::Item> {
-		use self::ChildsIter::*;
+		use self::ChildrenIter::*;
 		match *self {
 			Inl(ref mut iter) => iter.next_back(),
 			Ext(ref mut iter) => iter.next_back()
@@ -151,7 +151,7 @@ mod tests {
 	#[test]
 	fn none() {
 		let bool_const = expr::BoolConst::t();
-		let mut iter = bool_const.childs();
+		let mut iter = bool_const.children();
 		assert_eq!(iter.next(), None)
 	}
 
@@ -159,7 +159,7 @@ mod tests {
 	fn unary() {
 		let b = PlainExprTreeBuilder::default();
 		let expr = b.not(b.bool_const(false)).unwrap();
-		let mut iter = expr.childs();
+		let mut iter = expr.children();
 		assert_eq!(iter.next(), Some(&AnyExpr::from(expr::BoolConst::f())));
 		assert_eq!(iter.next(), None);
 	}
@@ -171,7 +171,7 @@ mod tests {
 			b.bool_const(false),
 			b.bool_const(true)
 		).unwrap();
-		let mut iter = expr.childs();
+		let mut iter = expr.children();
 		assert_eq!(iter.next(), Some(&AnyExpr::from(expr::BoolConst::f())));
 		assert_eq!(iter.next(), Some(&AnyExpr::from(expr::BoolConst::t())));
 		assert_eq!(iter.next(), None);
@@ -189,7 +189,7 @@ mod tests {
 	#[test]
 	fn ternary() {
 		let expr = test_cond();
-		let mut iter = expr.childs();
+		let mut iter = expr.children();
 		assert_eq!(iter.next(), Some(&AnyExpr::from(expr::BoolConst::f())));
 		assert_eq!(iter.next(), Some(&AnyExpr::from(expr::BitvecConst::from(42))));
 		assert_eq!(iter.next(), Some(&AnyExpr::from(expr::BitvecConst::from(5))));
@@ -210,7 +210,7 @@ mod tests {
 	#[test]
 	fn nary() {
 		let expr = big_test_expr();
-		let mut iter = expr.childs();
+		let mut iter = expr.children();
 		assert_eq!(iter.next(), Some(&AnyExpr::from(expr::BitvecConst::from(42))));
 		assert_eq!(iter.next(), Some(&AnyExpr::from(expr::BitvecConst::from(1337))));
 		assert_eq!(iter.next(), Some(&AnyExpr::from(expr::BitvecConst::from(77))));
@@ -222,7 +222,7 @@ mod tests {
 	#[test]
 	fn ternary_next_back() {
 		let expr = test_cond();
-		let mut iter = expr.childs();
+		let mut iter = expr.children();
 		assert_eq!(iter.next_back(), Some(&AnyExpr::from(expr::BitvecConst::from(5))));
 		assert_eq!(iter.next_back(), Some(&AnyExpr::from(expr::BitvecConst::from(42))));
 		assert_eq!(iter.next_back(), Some(&AnyExpr::from(expr::BoolConst::f())));
@@ -232,7 +232,7 @@ mod tests {
 	#[test]
 	fn nary_next_back() {
 		let expr = big_test_expr();
-		let mut iter = expr.childs();
+		let mut iter = expr.children();
 		assert_eq!(iter.next_back(), Some(&AnyExpr::from(expr::BitvecConst::from(5))));
 		assert_eq!(iter.next_back(), Some(&AnyExpr::from(expr::BitvecConst::from(0))));
 		assert_eq!(iter.next_back(), Some(&AnyExpr::from(expr::BitvecConst::from(77))));
@@ -244,7 +244,7 @@ mod tests {
 	#[test]
 	fn ternary_next_and_next_back() {
 		let expr = test_cond();
-		let mut iter = expr.childs();
+		let mut iter = expr.children();
 		assert_eq!(iter.next_back(), Some(&AnyExpr::from(expr::BitvecConst::from(5))));
 		assert_eq!(iter.next(), Some(&AnyExpr::from(expr::BoolConst::f())));
 		assert_eq!(iter.next_back(), Some(&AnyExpr::from(expr::BitvecConst::from(42))));
@@ -255,7 +255,7 @@ mod tests {
 	#[test]
 	fn nary_next_and_next_back() {
 		let expr = big_test_expr();
-		let mut iter = expr.childs();
+		let mut iter = expr.children();
 		assert_eq!(iter.next_back(), Some(&AnyExpr::from(expr::BitvecConst::from(5))));
 		assert_eq!(iter.next(), Some(&AnyExpr::from(expr::BitvecConst::from(42))));
 		assert_eq!(iter.next_back(), Some(&AnyExpr::from(expr::BitvecConst::from(0))));

--- a/src/ast/child_iters/child_iter_mut.rs
+++ b/src/ast/child_iters/child_iter_mut.rs
@@ -7,122 +7,122 @@ use std::mem;
 /// Re-exports commonly used items of this module.
 pub mod prelude {
     pub use super::{
-		ChildsIterMut	
+		ChildrenIterMut	
 	};
 }
 
 /// Iterator over mutable child expressions.
 #[derive(Debug)]
-pub enum ChildsIterMut<'p> {
-    Inl(InlChildsIterMut<'p>),
-    Ext(ExtChildsIterMut<'p>)
+pub enum ChildrenIterMut<'p> {
+    Inl(InlChildrenIterMut<'p>),
+    Ext(ExtChildrenIterMut<'p>)
 }
 
 #[derive(Debug)]
-pub struct InlChildsIterMut<'p> {
-    childs: [Option<&'p mut AnyExpr>; 3],
+pub struct InlChildrenIterMut<'p> {
+    children: [Option<&'p mut AnyExpr>; 3],
     begin: usize,
 	end: usize
 }
 
-impl<'p> InlChildsIterMut<'p> {
-    fn from_array(num_childs: usize, childs: [Option<&'p mut AnyExpr>; 3]) -> InlChildsIterMut {
-        InlChildsIterMut{childs, begin: 0, end: num_childs.saturating_sub(1)}
+impl<'p> InlChildrenIterMut<'p> {
+    fn from_array(num_children: usize, children: [Option<&'p mut AnyExpr>; 3]) -> InlChildrenIterMut {
+        InlChildrenIterMut{children, begin: 0, end: num_children.saturating_sub(1)}
     }
 
-    pub fn none() -> InlChildsIterMut<'p> {
-        InlChildsIterMut::from_array(0, [None, None, None])
+    pub fn none() -> InlChildrenIterMut<'p> {
+        InlChildrenIterMut::from_array(0, [None, None, None])
     }
 
-	pub fn unary(fst: &'p mut AnyExpr) -> InlChildsIterMut<'p> {
-		InlChildsIterMut::from_array(1, [Some(fst), None, None])
+	pub fn unary(fst: &'p mut AnyExpr) -> InlChildrenIterMut<'p> {
+		InlChildrenIterMut::from_array(1, [Some(fst), None, None])
 	}
 
-	pub fn binary(fst: &'p mut AnyExpr, snd: &'p mut AnyExpr) -> InlChildsIterMut<'p> {
-		InlChildsIterMut::from_array(2, [Some(fst), Some(snd), None])
+	pub fn binary(fst: &'p mut AnyExpr, snd: &'p mut AnyExpr) -> InlChildrenIterMut<'p> {
+		InlChildrenIterMut::from_array(2, [Some(fst), Some(snd), None])
 	}
 
-	pub fn ternary(fst: &'p mut AnyExpr, snd: &'p mut AnyExpr, trd: &'p mut AnyExpr) -> InlChildsIterMut<'p> {
-		InlChildsIterMut::from_array(3, [Some(fst), Some(snd), Some(trd)])
+	pub fn ternary(fst: &'p mut AnyExpr, snd: &'p mut AnyExpr, trd: &'p mut AnyExpr) -> InlChildrenIterMut<'p> {
+		InlChildrenIterMut::from_array(3, [Some(fst), Some(snd), Some(trd)])
 	}
 }
 
-impl<'p> Iterator for InlChildsIterMut<'p> {
+impl<'p> Iterator for InlChildrenIterMut<'p> {
     type Item = &'p mut AnyExpr;
 
     fn next(&mut self) -> Option<Self::Item> {
         // FIXME: Using replace here is a hack to fight the borrow-checker but works for now!
-        let elem = mem::replace(&mut self.childs[self.begin], None);
+        let elem = mem::replace(&mut self.children[self.begin], None);
         self.begin = cmp::min(self.begin + 1, 2);
         elem
     }
 }
 
-impl<'p> DoubleEndedIterator for InlChildsIterMut<'p> {
+impl<'p> DoubleEndedIterator for InlChildrenIterMut<'p> {
     fn next_back(&mut self) -> Option<Self::Item> {
         // FIXME: Using replace here is a hack to fight the borrow-checker but works for now!
-        let elem = mem::replace(&mut self.childs[self.end], None);
+        let elem = mem::replace(&mut self.children[self.end], None);
         self.end = self.end.saturating_sub(1);
         elem
     }
 }
 
 #[derive(Debug)]
-pub struct ExtChildsIterMut<'p> {
-    childs: slice::IterMut<'p, AnyExpr>
+pub struct ExtChildrenIterMut<'p> {
+    children: slice::IterMut<'p, AnyExpr>
 }
 
-impl<'p> ExtChildsIterMut<'p> {
-    fn from_slice(childs: &'p mut [AnyExpr]) -> ExtChildsIterMut {
-        ExtChildsIterMut{childs: childs.into_iter()}
+impl<'p> ExtChildrenIterMut<'p> {
+    fn from_slice(children: &'p mut [AnyExpr]) -> ExtChildrenIterMut {
+        ExtChildrenIterMut{children: children.into_iter()}
     }
 }
 
-impl<'p> Iterator for ExtChildsIterMut<'p> {
+impl<'p> Iterator for ExtChildrenIterMut<'p> {
     type Item = &'p mut AnyExpr;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.childs.next()
+        self.children.next()
     }
 }
 
-impl<'p> DoubleEndedIterator for ExtChildsIterMut<'p> {
+impl<'p> DoubleEndedIterator for ExtChildrenIterMut<'p> {
 	fn next_back(&mut self) -> Option<Self::Item> {
-		self.childs.next_back()
+		self.children.next_back()
 	}
 }
 
-impl<'p> ChildsIterMut<'p> {
-	pub fn none() -> ChildsIterMut<'p> {
-        ChildsIterMut::Inl(InlChildsIterMut::none())
+impl<'p> ChildrenIterMut<'p> {
+	pub fn none() -> ChildrenIterMut<'p> {
+        ChildrenIterMut::Inl(InlChildrenIterMut::none())
 	}
 
-	pub fn unary(fst: &'p mut AnyExpr) -> ChildsIterMut<'p> {
-        ChildsIterMut::Inl(InlChildsIterMut::unary(fst))
+	pub fn unary(fst: &'p mut AnyExpr) -> ChildrenIterMut<'p> {
+        ChildrenIterMut::Inl(InlChildrenIterMut::unary(fst))
 	}
 
-	pub fn binary(fst: &'p mut AnyExpr, snd: &'p mut AnyExpr) -> ChildsIterMut<'p> {
-        ChildsIterMut::Inl(InlChildsIterMut::binary(fst, snd))
+	pub fn binary(fst: &'p mut AnyExpr, snd: &'p mut AnyExpr) -> ChildrenIterMut<'p> {
+        ChildrenIterMut::Inl(InlChildrenIterMut::binary(fst, snd))
 	}
 
 	pub fn ternary(
 		fst: &'p mut AnyExpr,
 		snd: &'p mut AnyExpr,
-		trd: &'p mut AnyExpr) -> ChildsIterMut<'p>
+		trd: &'p mut AnyExpr) -> ChildrenIterMut<'p>
 	{
-		ChildsIterMut::Inl(InlChildsIterMut::ternary(fst, snd, trd))
+		ChildrenIterMut::Inl(InlChildrenIterMut::ternary(fst, snd, trd))
 	}
 
-	pub fn nary(childs: &'p mut [AnyExpr]) -> ChildsIterMut<'p> {
-		ChildsIterMut::Ext(ExtChildsIterMut::from_slice(childs))
+	pub fn nary(children: &'p mut [AnyExpr]) -> ChildrenIterMut<'p> {
+		ChildrenIterMut::Ext(ExtChildrenIterMut::from_slice(children))
 	}
 }
 
-impl<'p> Iterator for ChildsIterMut<'p> {
+impl<'p> Iterator for ChildrenIterMut<'p> {
 	type Item = &'p mut AnyExpr;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		use self::ChildsIterMut::*;
+		use self::ChildrenIterMut::*;
 		match *self {
 			Inl(ref mut iter) => iter.next(),
 			Ext(ref mut iter) => iter.next()
@@ -130,9 +130,9 @@ impl<'p> Iterator for ChildsIterMut<'p> {
 	}
 }
 
-impl<'p> DoubleEndedIterator for ChildsIterMut<'p> {
+impl<'p> DoubleEndedIterator for ChildrenIterMut<'p> {
 	fn next_back(&mut self) -> Option<Self::Item> {
-		use self::ChildsIterMut::*;
+		use self::ChildrenIterMut::*;
 		match *self {
 			Inl(ref mut iter) => iter.next_back(),
 			Ext(ref mut iter) => iter.next_back()
@@ -147,7 +147,7 @@ mod tests {
 	#[test]
 	fn none() {
 		let mut bool_const = expr::BoolConst::t();
-		let mut iter = bool_const.childs_mut();
+		let mut iter = bool_const.children_mut();
 		assert_eq!(iter.next(), None)
 	}
 
@@ -155,7 +155,7 @@ mod tests {
 	fn unary() {
 		let b = PlainExprTreeBuilder::default();
 		let mut expr = b.not(b.bool_const(false)).unwrap();
-		let mut iter = expr.childs_mut();
+		let mut iter = expr.children_mut();
 		assert_eq!(iter.next(), Some(&mut AnyExpr::from(expr::BoolConst::f())));
 		assert_eq!(iter.next(), None);
 	}
@@ -167,7 +167,7 @@ mod tests {
 			b.bool_const(false),
 			b.bool_const(true)
 		).unwrap();
-		let mut iter = expr.childs_mut();
+		let mut iter = expr.children_mut();
 		assert_eq!(iter.next(), Some(&mut AnyExpr::from(expr::BoolConst::f())));
 		assert_eq!(iter.next(), Some(&mut AnyExpr::from(expr::BoolConst::t())));
 		assert_eq!(iter.next(), None);
@@ -185,7 +185,7 @@ mod tests {
 	#[test]
 	fn ternary() {
 		let mut expr = test_cond();
-		let mut iter = expr.childs_mut();
+		let mut iter = expr.children_mut();
 		assert_eq!(iter.next(), Some(&mut AnyExpr::from(expr::BoolConst::f())));
 		assert_eq!(iter.next(), Some(&mut AnyExpr::from(expr::BitvecConst::from(42))));
 		assert_eq!(iter.next(), Some(&mut AnyExpr::from(expr::BitvecConst::from(5))));
@@ -206,7 +206,7 @@ mod tests {
 	#[test]
 	fn nary() {
 		let mut expr = big_test_expr();
-		let mut iter = expr.childs_mut();
+		let mut iter = expr.children_mut();
 		assert_eq!(iter.next(), Some(&mut AnyExpr::from(expr::BitvecConst::from(42))));
 		assert_eq!(iter.next(), Some(&mut AnyExpr::from(expr::BitvecConst::from(1337))));
 		assert_eq!(iter.next(), Some(&mut AnyExpr::from(expr::BitvecConst::from(77))));
@@ -218,7 +218,7 @@ mod tests {
 	#[test]
 	fn ternary_next_back() {
 		let mut expr = test_cond();
-		let mut iter = expr.childs_mut();
+		let mut iter = expr.children_mut();
 		assert_eq!(iter.next_back(), Some(&mut AnyExpr::from(expr::BitvecConst::from(5))));
 		assert_eq!(iter.next_back(), Some(&mut AnyExpr::from(expr::BitvecConst::from(42))));
 		assert_eq!(iter.next_back(), Some(&mut AnyExpr::from(expr::BoolConst::f())));
@@ -228,7 +228,7 @@ mod tests {
 	#[test]
 	fn nary_next_back() {
 		let mut expr = big_test_expr();
-		let mut iter = expr.childs_mut();
+		let mut iter = expr.children_mut();
 		assert_eq!(iter.next_back(), Some(&mut AnyExpr::from(expr::BitvecConst::from(5))));
 		assert_eq!(iter.next_back(), Some(&mut AnyExpr::from(expr::BitvecConst::from(0))));
 		assert_eq!(iter.next_back(), Some(&mut AnyExpr::from(expr::BitvecConst::from(77))));
@@ -240,7 +240,7 @@ mod tests {
 	#[test]
 	fn ternary_next_and_next_back() {
 		let mut expr = test_cond();
-		let mut iter = expr.childs_mut();
+		let mut iter = expr.children_mut();
 		assert_eq!(iter.next_back(), Some(&mut AnyExpr::from(expr::BitvecConst::from(5))));
 		assert_eq!(iter.next(), Some(&mut AnyExpr::from(expr::BoolConst::f())));
 		assert_eq!(iter.next_back(), Some(&mut AnyExpr::from(expr::BitvecConst::from(42))));
@@ -251,7 +251,7 @@ mod tests {
 	#[test]
 	fn nary_next_and_next_back() {
 		let mut expr = big_test_expr();
-		let mut iter = expr.childs_mut();
+		let mut iter = expr.children_mut();
 		assert_eq!(iter.next_back(), Some(&mut AnyExpr::from(expr::BitvecConst::from(5))));
 		assert_eq!(iter.next(), Some(&mut AnyExpr::from(expr::BitvecConst::from(42))));
 		assert_eq!(iter.next_back(), Some(&mut AnyExpr::from(expr::BitvecConst::from(0))));

--- a/src/ast/child_iters/into_child_iter.rs
+++ b/src/ast/child_iters/into_child_iter.rs
@@ -7,75 +7,75 @@ use std::iter::FromIterator;
 /// Re-exports commonly used items of this module.
 pub mod prelude {
     pub use super::{
-		IntoChildsIter	
+		IntoChildrenIter	
 	};
 }
 
 /// Consuming iterator over child expressions.
 /// 
 /// Can transform ownership.
-pub struct IntoChildsIter {
-	childs: smallvec::IntoIter<[AnyExpr; 3]>
+pub struct IntoChildrenIter {
+	children: smallvec::IntoIter<[AnyExpr; 3]>
 }
 
-impl FromIterator<AnyExpr> for IntoChildsIter {
-    fn from_iter<T>(iter: T) -> IntoChildsIter
+impl FromIterator<AnyExpr> for IntoChildrenIter {
+    fn from_iter<T>(iter: T) -> IntoChildrenIter
         where T: IntoIterator<Item = AnyExpr>
     {
-        IntoChildsIter{
-            childs: smallvec::SmallVec::from_iter(iter).into_iter()
+        IntoChildrenIter{
+            children: smallvec::SmallVec::from_iter(iter).into_iter()
         }
     }
 }
 
-impl<'parent> IntoChildsIter {
-	pub fn none() -> IntoChildsIter {
-        IntoChildsIter::from_iter(vec![])
+impl<'parent> IntoChildrenIter {
+	pub fn none() -> IntoChildrenIter {
+        IntoChildrenIter::from_iter(vec![])
 	}
 
-	pub fn unary(fst: AnyExpr) -> IntoChildsIter {
+	pub fn unary(fst: AnyExpr) -> IntoChildrenIter {
 		let mut vec = smallvec::SmallVec::new();
 		vec.push(fst);
-		IntoChildsIter{
-			childs: vec.into_iter()
+		IntoChildrenIter{
+			children: vec.into_iter()
 		}
 	}
 
-	pub fn binary(fst: AnyExpr, snd: AnyExpr) -> IntoChildsIter {
+	pub fn binary(fst: AnyExpr, snd: AnyExpr) -> IntoChildrenIter {
 		let mut vec = smallvec::SmallVec::new();
 		vec.push(fst);
 		vec.push(snd);
-		IntoChildsIter{
-			childs: vec.into_iter()
+		IntoChildrenIter{
+			children: vec.into_iter()
 		}
 	}
 
-	pub fn ternary(fst: AnyExpr, snd: AnyExpr, trd: AnyExpr) -> IntoChildsIter {
+	pub fn ternary(fst: AnyExpr, snd: AnyExpr, trd: AnyExpr) -> IntoChildrenIter {
 		let mut vec = smallvec::SmallVec::new();
 		vec.push(fst);
 		vec.push(snd);
 		vec.push(trd);
-		IntoChildsIter{
-			childs: vec.into_iter()
+		IntoChildrenIter{
+			children: vec.into_iter()
 		}
 	}
 
-	pub fn nary(childs: Vec<AnyExpr>) -> IntoChildsIter {
-		IntoChildsIter::from_iter(childs)
+	pub fn nary(children: Vec<AnyExpr>) -> IntoChildrenIter {
+		IntoChildrenIter::from_iter(children)
 	}
 }
 
-impl Iterator for IntoChildsIter {
+impl Iterator for IntoChildrenIter {
 	type Item = AnyExpr;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		self.childs.next()
+		self.children.next()
 	}
 }
 
-impl DoubleEndedIterator for IntoChildsIter {
+impl DoubleEndedIterator for IntoChildrenIter {
 	fn next_back(&mut self) -> Option<Self::Item> {
-		self.childs.next_back()
+		self.children.next_back()
 	}
 }
 
@@ -86,7 +86,7 @@ mod tests {
 	#[test]
 	fn none() {
 		let bool_const = expr::BoolConst::t();
-		let mut iter = bool_const.into_childs();
+		let mut iter = bool_const.into_children();
 		assert_eq!(iter.next(), None)
 	}
 
@@ -94,7 +94,7 @@ mod tests {
 	fn unary() {
 		let b = PlainExprTreeBuilder::default();
 		let expr = b.not(b.bool_const(false)).unwrap();
-		let mut iter = expr.into_childs();
+		let mut iter = expr.into_children();
 		assert_eq!(iter.next(), Some(AnyExpr::from(expr::BoolConst::f())));
 		assert_eq!(iter.next(), None);
 	}
@@ -106,7 +106,7 @@ mod tests {
 			b.bool_const(false),
 			b.bool_const(true)
 		).unwrap();
-		let mut iter = expr.into_childs();
+		let mut iter = expr.into_children();
 		assert_eq!(iter.next(), Some(AnyExpr::from(expr::BoolConst::f())));
 		assert_eq!(iter.next(), Some(AnyExpr::from(expr::BoolConst::t())));
 		assert_eq!(iter.next(), None);
@@ -124,7 +124,7 @@ mod tests {
 	#[test]
 	fn ternary() {
 		let expr = test_cond();
-		let mut iter = expr.into_childs();
+		let mut iter = expr.into_children();
 		assert_eq!(iter.next(), Some(AnyExpr::from(expr::BoolConst::f())));
 		assert_eq!(iter.next(), Some(AnyExpr::from(expr::BitvecConst::from(42))));
 		assert_eq!(iter.next(), Some(AnyExpr::from(expr::BitvecConst::from(5))));
@@ -145,7 +145,7 @@ mod tests {
 	#[test]
 	fn nary() {
 		let expr = big_test_expr();
-		let mut iter = expr.into_childs();
+		let mut iter = expr.into_children();
 		assert_eq!(iter.next(), Some(AnyExpr::from(expr::BitvecConst::from(42))));
 		assert_eq!(iter.next(), Some(AnyExpr::from(expr::BitvecConst::from(1337))));
 		assert_eq!(iter.next(), Some(AnyExpr::from(expr::BitvecConst::from(77))));
@@ -157,7 +157,7 @@ mod tests {
 	#[test]
 	fn ternary_next_back() {
 		let expr = test_cond();
-		let mut iter = expr.into_childs();
+		let mut iter = expr.into_children();
 		assert_eq!(iter.next_back(), Some(AnyExpr::from(expr::BitvecConst::from(5))));
 		assert_eq!(iter.next_back(), Some(AnyExpr::from(expr::BitvecConst::from(42))));
 		assert_eq!(iter.next_back(), Some(AnyExpr::from(expr::BoolConst::f())));
@@ -167,7 +167,7 @@ mod tests {
 	#[test]
 	fn nary_next_back() {
 		let expr = big_test_expr();
-		let mut iter = expr.into_childs();
+		let mut iter = expr.into_children();
 		assert_eq!(iter.next_back(), Some(AnyExpr::from(expr::BitvecConst::from(5))));
 		assert_eq!(iter.next_back(), Some(AnyExpr::from(expr::BitvecConst::from(0))));
 		assert_eq!(iter.next_back(), Some(AnyExpr::from(expr::BitvecConst::from(77))));
@@ -179,7 +179,7 @@ mod tests {
 	#[test]
 	fn ternary_next_and_next_back() {
 		let expr = test_cond();
-		let mut iter = expr.into_childs();
+		let mut iter = expr.into_children();
 		assert_eq!(iter.next_back(), Some(AnyExpr::from(expr::BitvecConst::from(5))));
 		assert_eq!(iter.next(), Some(AnyExpr::from(expr::BoolConst::f())));
 		assert_eq!(iter.next_back(), Some(AnyExpr::from(expr::BitvecConst::from(42))));
@@ -190,7 +190,7 @@ mod tests {
 	#[test]
 	fn nary_next_and_next_back() {
 		let expr = big_test_expr();
-		let mut iter = expr.into_childs();
+		let mut iter = expr.into_children();
 		assert_eq!(iter.next_back(), Some(AnyExpr::from(expr::BitvecConst::from(5))));
 		assert_eq!(iter.next(), Some(AnyExpr::from(expr::BitvecConst::from(42))));
 		assert_eq!(iter.next_back(), Some(AnyExpr::from(expr::BitvecConst::from(0))));

--- a/src/ast/child_iters/mod.rs
+++ b/src/ast/child_iters/mod.rs
@@ -3,27 +3,27 @@ mod traits;
 mod child_iter;
 mod child_iter_mut;
 mod into_child_iter;
-mod recursive_childs_iter;
+mod recursive_children_iter;
 
 pub use self::traits::prelude::*;
 pub use self::child_iter::prelude::*;
 pub use self::child_iter_mut::prelude::*;
 pub use self::into_child_iter::prelude::*;
-pub use self::recursive_childs_iter::prelude::*;
+pub use self::recursive_children_iter::prelude::*;
 
 pub mod prelude {
     pub use super::{
-        Childs,
-        ChildsMut,
-        IntoChilds,
-        ChildsIter,
-        ChildsIterMut,
-        IntoChildsIter,
+        Children,
+        ChildrenMut,
+        IntoChildren,
+        ChildrenIter,
+        ChildrenIterMut,
+        IntoChildrenIter,
         YieldEvent,
         AnyExprAndEvent,
-        RecursiveChildsIter,
-        childs_recursive_with_event,
-        childs_recursive_entering,
-        childs_recursive_leaving
+        RecursiveChildrenIter,
+        children_recursive_with_event,
+        children_recursive_entering,
+        children_recursive_leaving
     };
 }

--- a/src/ast/child_iters/traits.rs
+++ b/src/ast/child_iters/traits.rs
@@ -3,27 +3,27 @@ use ast::child_iters::prelude::*;
 /// Re-exports all commonly used items of this module.
 pub mod prelude {
     pub use super::{
-        Childs,
-        ChildsMut,
-        IntoChilds
+        Children,
+        ChildrenMut,
+        IntoChildren
     };
 }
 
-/// Types that implement this trait allow to traverse their childs immutably.
-pub trait Childs {
+/// Types that implement this trait allow to traverse their children immutably.
+pub trait Children {
     /// Iterates over the child expressions of `self` immutably.
-    fn childs(&self) -> ChildsIter;
+    fn children(&self) -> ChildrenIter;
 }
 
-/// Types that implement this trait allow to traverse their childs mutably.
-pub trait ChildsMut {
+/// Types that implement this trait allow to traverse their children mutably.
+pub trait ChildrenMut {
     /// Iterates over the child expressions of `self` mutably.
-    fn childs_mut(&mut self) -> ChildsIterMut;
+    fn children_mut(&mut self) -> ChildrenIterMut;
 }
 
 /// Types that implement this trait allow to be transformed
-/// into a consuming childs iter.
-pub trait IntoChilds {
-    /// Transforms `self` into a consuming childs iter.
-    fn into_childs(self) -> IntoChildsIter;
+/// into a consuming children iter.
+pub trait IntoChildren {
+    /// Transforms `self` into a consuming children iter.
+    fn into_children(self) -> IntoChildrenIter;
 }

--- a/src/ast/factory/builder.rs
+++ b/src/ast/factory/builder.rs
@@ -79,11 +79,11 @@ pub trait ExprTreeFactory {
     /// Create a new binary and expression with the given child expressions.
     fn and(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr>;
     /// Creates a new n-ary and expression with the given child expressions.
-    fn and_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr>;
+    fn and_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr>;
     /// Creates a new binary boolean equality expression with the given child expressions.
     fn bool_equals(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr>;
     /// Creates a new n-ary boolean equality expression with the given child expressions.
-    fn bool_equals_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr>;
+    fn bool_equals_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr>;
     /// Creates a new binary implies expression with the given child expressions.
     fn implies(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr>;
     /// Creates a new logical not expression for the given child expression.
@@ -91,7 +91,7 @@ pub trait ExprTreeFactory {
     /// Creates a new binary or expression for the given child expressions.
     fn or(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr>;
     /// Creates a new n-ary or expression for the given child expressions.
-    fn or_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr>;
+    fn or_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr>;
     /// Creates a new binary or expression for the given child expressions.
     fn xor(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr>;
 
@@ -105,7 +105,7 @@ pub trait ExprTreeFactory {
     /// Creates a new binary bitvec equality expression with the given child expressions.
     fn bitvec_equals(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr>;
     /// Creates a new n-ary bitvec equality expression with the given child expressions.
-    fn bitvec_equals_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr>;
+    fn bitvec_equals_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr>;
     /// Creates a new bitvec constant with the given type and value.
     fn bitvec_const<V>(self, ty: BitvecTy, value: V) -> Result<AnyExpr>
         where V: Into<expr::BitvecConst>;
@@ -114,13 +114,13 @@ pub trait ExprTreeFactory {
     /// Creates a new binary bitvec add expression with the given child expressions.
     fn bitvec_add(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr>;
     /// Creates a new n-ary bitvec add expression with the given child expressions.
-    fn bitvec_add_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr>;
+    fn bitvec_add_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr>;
     /// Creates a new binary bitvec subtract expression for the given child expressions.
     fn bitvec_sub(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr>;
     /// Creates a new binary bitvec multiply expression with the given child expressions.
     fn bitvec_mul(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr>;
     /// Creates a new n-ary bitvec multiply expression with the given child expressions.
-    fn bitvec_mul_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr>;
+    fn bitvec_mul_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr>;
     /// Creates a new binary bitvec signed division expression for the given child expressions.
     fn bitvec_sdiv(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr>;
     /// Creates a new binary bitvec signed modulo expression for the given child expressions.
@@ -137,11 +137,11 @@ pub trait ExprTreeFactory {
     /// Create a new binary bitwise and expression with the given child expressions.
     fn bitvec_and(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr>;
     /// Creates a new n-ary bitwise and expression with the given child expressions.
-    fn bitvec_and_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr>;
+    fn bitvec_and_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr>;
     /// Create a new binary bitwise or expression with the given child expressions.
     fn bitvec_or(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr>;
     /// Creates a new n-ary bitwise or expression with the given child expressions.
-    fn bitvec_or_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr>;
+    fn bitvec_or_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr>;
     /// Creates a new binary bitvec xor expression for the given child expressions.
     fn bitvec_xor(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr>;
 
@@ -225,16 +225,16 @@ impl<F> ExprTreeBuilder<F>
     /// 
     /// This is just a utility method that helps with unwrapping the given
     /// child expressions before forwarding them to the factory method.
-    fn create_nary_expr<I, E, C>(self, constructor: C, childs: I) -> Result<AnyExpr>
+    fn create_nary_expr<I, E, C>(self, constructor: C, children: I) -> Result<AnyExpr>
         where I: IntoIterator<Item=E>,
               E: IntoAnyExprOrError,
               C: Fn(F, Vec<AnyExpr>) -> Result<AnyExpr>
     {
-        let childs = childs
+        let children = children
             .into_iter()
             .map(|c| c.into_any_expr_or_error())
             .collect::<Result<Vec<AnyExpr>>>()?;
-        constructor(self.factory(), childs)
+        constructor(self.factory(), children)
     }
 }
 
@@ -295,11 +295,11 @@ impl<F> ExprTreeBuilder<F>
     }
 
     /// Creates a new n-ary and expression with the given child expressions.
-    pub fn and_n<I, E>(self, childs: I) -> Result<AnyExpr>
+    pub fn and_n<I, E>(self, children: I) -> Result<AnyExpr>
         where I: IntoIterator<Item=E>,
               E: IntoAnyExprOrError
     {
-        self.create_nary_expr(F::and_n, childs)
+        self.create_nary_expr(F::and_n, children)
     }
 
     /// Creates a new binary boolean equality expression with the given child expressions.
@@ -311,11 +311,11 @@ impl<F> ExprTreeBuilder<F>
     }
 
     /// Creates a new n-ary boolean equality expression with the given child expressions.
-    pub fn bool_equals_n<I, E>(self, childs: I) -> Result<AnyExpr>
+    pub fn bool_equals_n<I, E>(self, children: I) -> Result<AnyExpr>
         where I: IntoIterator<Item=E>,
               E: IntoAnyExprOrError
     {
-        self.create_nary_expr(F::bool_equals_n, childs)
+        self.create_nary_expr(F::bool_equals_n, children)
     }
 
     /// Creates a new binary implies expression with the given child expressions.
@@ -343,11 +343,11 @@ impl<F> ExprTreeBuilder<F>
     }
 
     /// Creates a new n-ary or expression with the given child expressions.
-    pub fn or_n<I, E>(self, childs: I) -> Result<AnyExpr>
+    pub fn or_n<I, E>(self, children: I) -> Result<AnyExpr>
         where I: IntoIterator<Item=E>,
               E: IntoAnyExprOrError
     {
-        self.create_nary_expr(F::or_n, childs)
+        self.create_nary_expr(F::or_n, children)
     }
 
     /// Creates a new binary xor expression with the given child expressions.
@@ -414,11 +414,11 @@ impl<F> ExprTreeBuilder<F>
     }
 
     /// Creates a new n-ary bitvec add expression with the given child expressions.
-    pub fn bitvec_add_n<I, E>(self, childs: I) -> Result<AnyExpr>
+    pub fn bitvec_add_n<I, E>(self, children: I) -> Result<AnyExpr>
         where I: IntoIterator<Item=E>,
               E: IntoAnyExprOrError
     {
-        self.create_nary_expr(F::bitvec_add_n, childs)
+        self.create_nary_expr(F::bitvec_add_n, children)
     }
 
     /// Creates a new binary bitvec subtract expression with the given child expressions.
@@ -438,11 +438,11 @@ impl<F> ExprTreeBuilder<F>
     }
 
     /// Creates a new n-ary bitvec multiply expression with the given child expressions.
-    pub fn bitvec_mul_n<I, E>(self, childs: I) -> Result<AnyExpr>
+    pub fn bitvec_mul_n<I, E>(self, children: I) -> Result<AnyExpr>
         where I: IntoIterator<Item=E>,
               E: IntoAnyExprOrError
     {
-        self.create_nary_expr(F::bitvec_mul_n, childs)
+        self.create_nary_expr(F::bitvec_mul_n, children)
     }
 
     /// Creates a new binary signed division expression with the given child expressions.
@@ -499,11 +499,11 @@ impl<F> ExprTreeBuilder<F>
     }
 
     /// Creates a new n-ary bitwise and expression with the given child expressions.
-    pub fn bitvec_and_n<I, E>(self, childs: I) -> Result<AnyExpr>
+    pub fn bitvec_and_n<I, E>(self, children: I) -> Result<AnyExpr>
         where I: IntoIterator<Item=E>,
               E: IntoAnyExprOrError
     {
-        self.create_nary_expr(F::bitvec_and_n, childs)
+        self.create_nary_expr(F::bitvec_and_n, children)
     }
 
     /// Creates a new binary bitwise or expression with the given child expressions.
@@ -515,11 +515,11 @@ impl<F> ExprTreeBuilder<F>
     }
 
     /// Creates a new n-ary bitwise or expression with the given child expressions.
-    pub fn bitvec_or_n<I, E>(self, childs: I) -> Result<AnyExpr>
+    pub fn bitvec_or_n<I, E>(self, children: I) -> Result<AnyExpr>
         where I: IntoIterator<Item=E>,
               E: IntoAnyExprOrError
     {
-        self.create_nary_expr(F::bitvec_or_n, childs)
+        self.create_nary_expr(F::bitvec_or_n, children)
     }
 
     /// Create a new bitwise not expression for the given child expression.
@@ -592,11 +592,11 @@ impl<F> ExprTreeBuilder<F>
     }
 
     /// Creates a new n-ary bitvector equality expression with the given child expressions.
-    pub fn bitvec_equals_n<I, E>(self, childs: I) -> Result<AnyExpr>
+    pub fn bitvec_equals_n<I, E>(self, children: I) -> Result<AnyExpr>
         where I: IntoIterator<Item=E>,
               E: IntoAnyExprOrError
     {
-        self.create_nary_expr(F::bitvec_equals_n, childs)
+        self.create_nary_expr(F::bitvec_equals_n, children)
     }
 
     /// Creates a new binary signed greater-than-or-equals expression with the given child expressions.

--- a/src/ast/factory/plain_factory.rs
+++ b/src/ast/factory/plain_factory.rs
@@ -53,16 +53,16 @@ impl ExprTreeFactory for PlainExprTreeFactory {
 		expr::And::binary(lhs, rhs).map(AnyExpr::from)
 	}
 
-    fn and_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr> {
-		expr::And::nary(childs).map(AnyExpr::from)
+    fn and_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr> {
+		expr::And::nary(children).map(AnyExpr::from)
 	}
 
     fn bool_equals(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr> {
 		expr::BoolEquals::binary(lhs, rhs).map(AnyExpr::from)
 	}
 
-    fn bool_equals_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr> {
-		expr::BoolEquals::nary(childs).map(AnyExpr::from)
+    fn bool_equals_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr> {
+		expr::BoolEquals::nary(children).map(AnyExpr::from)
 	}
 
     fn implies(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr> {
@@ -77,8 +77,8 @@ impl ExprTreeFactory for PlainExprTreeFactory {
 		expr::Or::binary(lhs, rhs).map(AnyExpr::from)
 	}
 
-    fn or_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr> {
-		expr::Or::nary(childs).map(AnyExpr::from)
+    fn or_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr> {
+		expr::Or::nary(children).map(AnyExpr::from)
 	}
 
     fn xor(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr> {
@@ -97,8 +97,8 @@ impl ExprTreeFactory for PlainExprTreeFactory {
 		expr::BitvecEquals::binary(lhs, rhs).map(AnyExpr::from)
     }
 
-    fn bitvec_equals_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr> {
-        expr::BitvecEquals::nary(childs).map(AnyExpr::from)
+    fn bitvec_equals_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr> {
+        expr::BitvecEquals::nary(children).map(AnyExpr::from)
     }
 
     fn bitvec_const<V>(self, ty: BitvecTy, value: V) -> Result<AnyExpr>
@@ -120,8 +120,8 @@ impl ExprTreeFactory for PlainExprTreeFactory {
 		expr::Add::binary(lhs, rhs).map(AnyExpr::from)
 	}
 
-    fn bitvec_add_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr> {
-		expr::Add::nary(childs).map(AnyExpr::from)
+    fn bitvec_add_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr> {
+		expr::Add::nary(children).map(AnyExpr::from)
 	}
 
     fn bitvec_sub(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr> {
@@ -132,8 +132,8 @@ impl ExprTreeFactory for PlainExprTreeFactory {
 		expr::Mul::binary(lhs, rhs).map(AnyExpr::from)
 	}
 
-    fn bitvec_mul_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr> {
-		expr::Mul::nary(childs).map(AnyExpr::from)
+    fn bitvec_mul_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr> {
+		expr::Mul::nary(children).map(AnyExpr::from)
 	}
 
     fn bitvec_sdiv(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr> {
@@ -164,16 +164,16 @@ impl ExprTreeFactory for PlainExprTreeFactory {
 		expr::BitAnd::binary(lhs, rhs).map(AnyExpr::from)
 	}
 
-    fn bitvec_and_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr> {
-		expr::BitAnd::nary(childs).map(AnyExpr::from)
+    fn bitvec_and_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr> {
+		expr::BitAnd::nary(children).map(AnyExpr::from)
 	}
 
     fn bitvec_or(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr> {
 		expr::BitOr::binary(lhs, rhs).map(AnyExpr::from)
 	}
 
-    fn bitvec_or_n(self, childs: Vec<AnyExpr>) -> Result<AnyExpr> {
-		expr::BitOr::nary(childs).map(AnyExpr::from)
+    fn bitvec_or_n(self, children: Vec<AnyExpr>) -> Result<AnyExpr> {
+		expr::BitOr::nary(children).map(AnyExpr::from)
 	}
 
     fn bitvec_xor(self, lhs: AnyExpr, rhs: AnyExpr) -> Result<AnyExpr> {

--- a/src/ast/formulas/binexpr.rs
+++ b/src/ast/formulas/binexpr.rs
@@ -16,7 +16,7 @@ pub mod prelude {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BinBoolExpr<M> {
     /// The two child expressions.
-    pub childs: P<BinExprChilds>,
+    pub children: P<BinExprChildren>,
     /// Marker to differentiate bool expressions from each
     /// other using the type system.
     marker: PhantomData<M>
@@ -36,27 +36,27 @@ impl<M> BinBoolExpr<M> {
         let rhs = rhs.into();
         checks::expect_bool_ty(&lhs)?;
         checks::expect_bool_ty(&rhs)?;
-        Ok(Self{ childs: BinExprChilds::new_boxed(lhs, rhs), marker: PhantomData })
+        Ok(Self{ children: BinExprChildren::new_boxed(lhs, rhs), marker: PhantomData })
     }
 }
 
 impl<M> BoolExpr for BinBoolExpr<M> where Self: Into<AnyExpr> {}
 
-impl<M> Childs for BinBoolExpr<M> {
-    fn childs(&self) -> ChildsIter {
-        self.childs.childs()
+impl<M> Children for BinBoolExpr<M> {
+    fn children(&self) -> ChildrenIter {
+        self.children.children()
     }
 }
 
-impl<M> ChildsMut for BinBoolExpr<M> {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        self.childs.childs_mut()
+impl<M> ChildrenMut for BinBoolExpr<M> {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        self.children.children_mut()
     }
 }
 
-impl<M> IntoChilds for BinBoolExpr<M> {
-    fn into_childs(self) -> IntoChildsIter {
-        self.childs.into_childs()
+impl<M> IntoChildren for BinBoolExpr<M> {
+    fn into_children(self) -> IntoChildrenIter {
+        self.children.into_children()
     }
 }
 

--- a/src/ast/formulas/bool_const.rs
+++ b/src/ast/formulas/bool_const.rs
@@ -39,21 +39,21 @@ impl BoolConst {
 
 impl BoolExpr for BoolConst {}
 
-impl Childs for BoolConst {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::none()
+impl Children for BoolConst {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::none()
     }
 }
 
-impl ChildsMut for BoolConst {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::none()
+impl ChildrenMut for BoolConst {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::none()
     }
 }
 
-impl IntoChilds for BoolConst {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::none()
+impl IntoChildren for BoolConst {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::none()
     }
 }
 

--- a/src/ast/formulas/nary_expr.rs
+++ b/src/ast/formulas/nary_expr.rs
@@ -17,7 +17,7 @@ pub mod prelude {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NaryBoolExpr<M> {
     /// The child formula expressions.
-    pub childs: Vec<AnyExpr>,
+    pub children: Vec<AnyExpr>,
     /// Marker to differentiate bool expressions from each
     /// other using the type system.
     marker: PhantomData<M>
@@ -30,7 +30,7 @@ impl<M> NaryBoolExpr<M> {
     /// 
     /// This is just a convenience method and performs no type checking on its arguments.
     fn from_vec(children: Vec<AnyExpr>) -> Self {
-        Self{ childs: children, marker: PhantomData }
+        Self{ children: children, marker: PhantomData }
     }
 
     /// Returns a new n-ary formula expression with the given child expressions.
@@ -81,17 +81,17 @@ impl<M> NaryBoolExpr<M> {
     /// 
     /// - If the given iterator has less than two elements.
     /// - If not all expressions yielded by the given iteration are of boolean type.
-    pub fn nary<I>(childs: I) -> Result<Self, String>
+    pub fn nary<I>(children: I) -> Result<Self, String>
         where I: IntoIterator<Item = AnyExpr>
     {
-        let childs = childs.into_iter().collect::<Vec<_>>();
-        if childs.len() < 2 {
+        let children = children.into_iter().collect::<Vec<_>>();
+        if children.len() < 2 {
             return Err("Requires at least 2 child expressions to create an n-ary formula expression.".into())
         }
-        if childs.iter().any(|e| e.ty() != Type::Bool) {
+        if children.iter().any(|e| e.ty() != Type::Bool) {
             return Err("Requires all child expressions to be of boolean type.".into())
         }
-        Ok(Self::from_vec(childs))
+        Ok(Self::from_vec(children))
     }
 }
 
@@ -99,21 +99,21 @@ impl<M> BoolExpr for NaryBoolExpr<M>
     where Self: Into<AnyExpr>
 {}
 
-impl<M> Childs for NaryBoolExpr<M> {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::nary(&self.childs)
+impl<M> Children for NaryBoolExpr<M> {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::nary(&self.children)
     }
 }
 
-impl<M> ChildsMut for NaryBoolExpr<M> {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::nary(&mut self.childs)
+impl<M> ChildrenMut for NaryBoolExpr<M> {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::nary(&mut self.children)
     }
 }
 
-impl<M> IntoChilds for NaryBoolExpr<M> {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::nary(self.childs)
+impl<M> IntoChildren for NaryBoolExpr<M> {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::nary(self.children)
     }
 }
 
@@ -133,13 +133,13 @@ impl<M> HasKind for NaryBoolExpr<M>
 
 impl<M> HasArity for NaryBoolExpr<M> {
     fn arity(&self) -> usize {
-        self.childs.len()
+        self.children.len()
     }
 }
 
 impl<M> DedupChildren for NaryBoolExpr<M> {
     fn dedup_children(&mut self) {
-        self.childs.dedup()
+        self.children.dedup()
     }
 }
 
@@ -147,7 +147,7 @@ impl<M> SortChildren for NaryBoolExpr<M> {
     fn sort_children_by<F>(&mut self, comparator: F)
         where F: FnMut(&AnyExpr, &AnyExpr) -> Ordering
     {
-        self.childs.sort_unstable_by(comparator)
+        self.children.sort_unstable_by(comparator)
     }
 }
 
@@ -155,6 +155,6 @@ impl<M> RetainChildren for NaryBoolExpr<M> {
     fn retain_children<P>(&mut self, predicate: P)
         where P: FnMut(&AnyExpr) -> bool
     {
-        self.childs.retain(predicate);
+        self.children.retain(predicate);
     }
 }

--- a/src/ast/formulas/not.rs
+++ b/src/ast/formulas/not.rs
@@ -45,21 +45,21 @@ impl Not {
 
 impl BoolExpr for Not {}
 
-impl Childs for Not {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::unary(&self.child)
+impl Children for Not {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::unary(&self.child)
     }
 }
 
-impl ChildsMut for Not {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::unary(&mut self.child)
+impl ChildrenMut for Not {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::unary(&mut self.child)
     }
 }
 
-impl IntoChilds for Not {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::unary(*self.child)
+impl IntoChildren for Not {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::unary(*self.child)
     }
 }
 

--- a/src/ast/ite.rs
+++ b/src/ast/ite.rs
@@ -4,7 +4,7 @@ use ast::prelude::*;
 pub mod prelude {
     pub use super::{
         IfThenElse,
-        IfThenElseChilds
+        IfThenElseChildren
     };
 }
 
@@ -12,14 +12,14 @@ pub mod prelude {
 /// 
 /// # Note
 /// 
-/// - This has a `Type` that is dependend on its childs.
+/// - This has a `Type` that is dependend on its children.
 /// - Its condition is always of boolean type.
-/// - Its `then_case` and `else_case` childs are asserted
+/// - Its `then_case` and `else_case` children are asserted
 ///   to be of same `Type` as their parent `IfThenElse` expression.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct IfThenElse{
     /// The children of this expression.
-	pub childs: P<IfThenElseChilds>,
+	pub children: P<IfThenElseChildren>,
     /// The type of this expression.
 	pub ty: Type
 }
@@ -34,7 +34,7 @@ pub struct IfThenElse{
 /// This also has the positive effect of storing all child
 /// expressions densely in the memory.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct IfThenElseChilds {
+pub struct IfThenElseChildren {
     /// The condition of the parent `IfThenElse` expression.
     /// 
     /// This must always be of boolean type.
@@ -53,14 +53,14 @@ pub struct IfThenElseChilds {
 	pub else_case: AnyExpr
 }
 
-impl IfThenElseChilds {
-    /// Consumes `self` and returns both of its childs as tuple.
-    pub fn into_childs_tuple(self) -> (AnyExpr, AnyExpr, AnyExpr) {
+impl IfThenElseChildren {
+    /// Consumes `self` and returns both of its children as tuple.
+    pub fn into_children_tuple(self) -> (AnyExpr, AnyExpr, AnyExpr) {
         (self.cond, self.then_case, self.else_case)
     }
 
     /// Returns a tuple of mutable references to the child expressions.
-    pub fn as_childs_tuple_mut(&mut self) -> (&mut AnyExpr, &mut AnyExpr, &mut AnyExpr) {
+    pub fn as_children_tuple_mut(&mut self) -> (&mut AnyExpr, &mut AnyExpr, &mut AnyExpr) {
         (&mut self.cond, &mut self.then_case, &mut self.else_case)
     }
 
@@ -101,36 +101,36 @@ impl IfThenElse {
         let common_ty = common_ty(&then_case, &else_case).unwrap();
         IfThenElse{
             ty: common_ty,
-            childs: P::new(IfThenElseChilds{cond, then_case, else_case})
+            children: P::new(IfThenElseChildren{cond, then_case, else_case})
         }
     }
 
     /// Swaps then and else case child expressions.
     pub fn swap_then_else(&mut self) {
-        self.childs.swap_then_else()
+        self.children.swap_then_else()
     }
 
     /// Returns a tuple of mutable references to the child expressions.
-    pub fn as_childs_tuple_mut(&mut self) -> (&mut AnyExpr, &mut AnyExpr, &mut AnyExpr) {
-        self.childs.as_childs_tuple_mut()
+    pub fn as_children_tuple_mut(&mut self) -> (&mut AnyExpr, &mut AnyExpr, &mut AnyExpr) {
+        self.children.as_children_tuple_mut()
     }
 }
 
-impl Childs for IfThenElseChilds {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::ternary(&self.cond, &self.then_case, &self.else_case)
+impl Children for IfThenElseChildren {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::ternary(&self.cond, &self.then_case, &self.else_case)
     }
 }
 
-impl ChildsMut for IfThenElseChilds {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::ternary(&mut self.cond, &mut self.then_case, &mut self.else_case)
+impl ChildrenMut for IfThenElseChildren {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::ternary(&mut self.cond, &mut self.then_case, &mut self.else_case)
     }
 }
 
-impl IntoChilds for IfThenElseChilds {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::ternary(self.cond, self.then_case, self.else_case)
+impl IntoChildren for IfThenElseChildren {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::ternary(self.cond, self.then_case, self.else_case)
     }
 }
 
@@ -158,20 +158,20 @@ impl From<IfThenElse> for AnyExpr {
     }
 }
 
-impl Childs for IfThenElse {
-    fn childs(&self) -> ChildsIter {
-        self.childs.childs()
+impl Children for IfThenElse {
+    fn children(&self) -> ChildrenIter {
+        self.children.children()
     }
 }
 
-impl ChildsMut for IfThenElse {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        self.childs.childs_mut()
+impl ChildrenMut for IfThenElse {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        self.children.children_mut()
     }
 }
 
-impl IntoChilds for IfThenElse {
-    fn into_childs(self) -> IntoChildsIter {
-        self.childs.into_childs()
+impl IntoChildren for IfThenElse {
+    fn into_children(self) -> IntoChildrenIter {
+        self.children.into_children()
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,6 +1,6 @@
 mod arity;
 mod child_iters;
-mod binexpr_childs;
+mod binexpr_children;
 mod factory;
 mod ty;
 mod expr_kind;
@@ -27,27 +27,27 @@ pub use self::ty::{
     common_ty,
     have_common_ty,
 };
-pub use self::binexpr_childs::{
-    BinExprChilds
+pub use self::binexpr_children::{
+    BinExprChildren
 };
 pub use self::ite::{
-    IfThenElseChilds
+    IfThenElseChildren
 };
 pub use self::child_iters::{
-    ChildsIter,
-    ChildsIterMut,
-    IntoChildsIter,
-    Childs,
-    ChildsMut,
-    IntoChilds,
+    ChildrenIter,
+    ChildrenIterMut,
+    IntoChildrenIter,
+    Children,
+    ChildrenMut,
+    IntoChildren,
 
     YieldEvent,
     AnyExprAndEvent,
-    RecursiveChildsIter,
+    RecursiveChildrenIter,
 
-    childs_recursive_with_event,
-    childs_recursive_entering,
-    childs_recursive_leaving
+    children_recursive_with_event,
+    children_recursive_entering,
+    children_recursive_leaving
 };
 pub use self::factory::{
     IntoAnyExprOrError,

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -186,20 +186,20 @@ impl From<Symbol> for AnyExpr {
     }
 }
 
-impl Childs for Symbol {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::none()
+impl Children for Symbol {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::none()
     }
 }
 
-impl ChildsMut for Symbol {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::none()
+impl ChildrenMut for Symbol {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::none()
     }
 }
 
-impl IntoChilds for Symbol {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::none()
+impl IntoChildren for Symbol {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::none()
     }
 }

--- a/src/ast/terms/arithmetic/bitvec_const.rs
+++ b/src/ast/terms/arithmetic/bitvec_const.rs
@@ -161,21 +161,21 @@ impl From<ApInt> for BitvecConst {
     }
 }
 
-impl Childs for BitvecConst {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::none()
+impl Children for BitvecConst {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::none()
     }
 }
 
-impl ChildsMut for BitvecConst {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::none()
+impl ChildrenMut for BitvecConst {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::none()
     }
 }
 
-impl IntoChilds for BitvecConst {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::none()
+impl IntoChildren for BitvecConst {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::none()
     }
 }
 

--- a/src/ast/terms/arithmetic/neg.rs
+++ b/src/ast/terms/arithmetic/neg.rs
@@ -51,21 +51,21 @@ impl Neg {
     }
 }
 
-impl Childs for Neg {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::unary(&self.child)
+impl Children for Neg {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::unary(&self.child)
     }
 }
 
-impl ChildsMut for Neg {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::unary(&mut self.child)
+impl ChildrenMut for Neg {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::unary(&mut self.child)
     }
 }
 
-impl IntoChilds for Neg {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::unary(*self.child)
+impl IntoChildren for Neg {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::unary(*self.child)
     }
 }
 

--- a/src/ast/terms/array/read.rs
+++ b/src/ast/terms/array/read.rs
@@ -11,18 +11,18 @@ pub mod prelude {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ArrayRead {
     /// The two child expressions of this array read expression.
-    pub childs: P<ArrayReadChilds>,
+    pub children: P<ArrayReadChildren>,
     /// The bit width of this read expression.
     /// 
     /// This is a cache for the value bit width of the child
     /// array expression to prevent the indirection over the
-    /// childs structure if this value is used often.
+    /// children structure if this value is used often.
     pub bitvec_ty: BitvecTy
 }
 
 /// The child expressions of a `Read` expression.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ArrayReadChilds {
+pub struct ArrayReadChildren {
     /// The array expression.
     /// 
     /// This must be of array type.
@@ -33,20 +33,20 @@ pub struct ArrayReadChilds {
     pub index: AnyExpr
 }
 
-impl ArrayReadChilds {
-    /// Creates a new `ArrayReadChilds` object.
+impl ArrayReadChildren {
+    /// Creates a new `ArrayReadChildren` object.
     /// 
     /// Does not check any invariants of `ArrayRead`.
     /// This function should be marked unsafe since it fails to hold any guarantees.
-    pub fn new(array: AnyExpr, index: AnyExpr) -> ArrayReadChilds {
-        ArrayReadChilds{array, index}
+    pub fn new(array: AnyExpr, index: AnyExpr) -> ArrayReadChildren {
+        ArrayReadChildren{array, index}
     }
 
-    /// Creates a new boxed `ArrayReadChilds` object.
+    /// Creates a new boxed `ArrayReadChildren` object.
     /// 
-    /// This is just a convenience wrapper around `ArrayReadChilds::new`.
-    pub fn new_boxed(array: AnyExpr, index: AnyExpr) -> P<ArrayReadChilds> {
-        P::new(ArrayReadChilds::new(array, index))
+    /// This is just a convenience wrapper around `ArrayReadChildren::new`.
+    pub fn new_boxed(array: AnyExpr, index: AnyExpr) -> P<ArrayReadChildren> {
+        P::new(ArrayReadChildren::new(array, index))
     }
 }
 
@@ -67,25 +67,25 @@ impl ArrayRead {
         let index = index.into();
         let array_ty = checks::expect_array_ty(&array)?;
         checks::expect_concrete_bitvec_ty(&index, array_ty.index_ty())?;
-        Ok(ArrayRead{ bitvec_ty: array_ty.value_ty(), childs: ArrayReadChilds::new_boxed(array, index) })
+        Ok(ArrayRead{ bitvec_ty: array_ty.value_ty(), children: ArrayReadChildren::new_boxed(array, index) })
     }
 }
 
-impl Childs for ArrayReadChilds {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::binary(&self.array, &self.index)
+impl Children for ArrayReadChildren {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::binary(&self.array, &self.index)
     }
 }
 
-impl ChildsMut for ArrayReadChilds {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::binary(&mut self.array, &mut self.index)
+impl ChildrenMut for ArrayReadChildren {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::binary(&mut self.array, &mut self.index)
     }
 }
 
-impl IntoChilds for ArrayReadChilds {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::binary(self.array, self.index)
+impl IntoChildren for ArrayReadChildren {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::binary(self.array, self.index)
     }
 }
 
@@ -113,20 +113,20 @@ impl From<ArrayRead> for AnyExpr {
     }
 }
 
-impl Childs for ArrayRead {
-    fn childs(&self) -> ChildsIter {
-        self.childs.childs()
+impl Children for ArrayRead {
+    fn children(&self) -> ChildrenIter {
+        self.children.children()
     }
 }
 
-impl ChildsMut for ArrayRead {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        self.childs.childs_mut()
+impl ChildrenMut for ArrayRead {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        self.children.children_mut()
     }
 }
 
-impl IntoChilds for ArrayRead {
-    fn into_childs(self) -> IntoChildsIter {
-        self.childs.into_childs()
+impl IntoChildren for ArrayRead {
+    fn into_children(self) -> IntoChildrenIter {
+        self.children.into_children()
     }
 }

--- a/src/ast/terms/array/write.rs
+++ b/src/ast/terms/array/write.rs
@@ -11,7 +11,7 @@ pub mod prelude {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ArrayWrite {
     /// The two child expressions of this array read expression.
-    pub childs: P<ArrayWriteChilds>,
+    pub children: P<ArrayWriteChildren>,
     /// The type of this array expr.
     /// 
     /// This mainly stores the index bit width and value bit width.
@@ -20,7 +20,7 @@ pub struct ArrayWrite {
 
 /// The child expressions of a `Read` expression.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ArrayWriteChilds {
+pub struct ArrayWriteChildren {
     /// The array expression.
     /// 
     /// This must be of array type.
@@ -38,20 +38,20 @@ pub struct ArrayWriteChilds {
     pub value: AnyExpr
 }
 
-impl ArrayWriteChilds {
-    /// Creates a new `ArrayWriteChilds` object.
+impl ArrayWriteChildren {
+    /// Creates a new `ArrayWriteChildren` object.
     /// 
     /// Does not check any invariants of `ArrayWrite`.
     /// This function should be marked unsafe since it fails to hold any guarantees.
-    pub fn new(array: AnyExpr, index: AnyExpr, value: AnyExpr) -> ArrayWriteChilds {
-        ArrayWriteChilds{array, index, value}
+    pub fn new(array: AnyExpr, index: AnyExpr, value: AnyExpr) -> ArrayWriteChildren {
+        ArrayWriteChildren{array, index, value}
     }
 
-    /// Creates a new boxed `ArrayWriteChilds` object.
+    /// Creates a new boxed `ArrayWriteChildren` object.
     /// 
-    /// This is just a convenience wrapper around `ArrayWriteChilds::new`.
-    pub fn new_boxed(array: AnyExpr, index: AnyExpr, value: AnyExpr) -> P<ArrayWriteChilds> {
-        P::new(ArrayWriteChilds::new(array, index, value))
+    /// This is just a convenience wrapper around `ArrayWriteChildren::new`.
+    pub fn new_boxed(array: AnyExpr, index: AnyExpr, value: AnyExpr) -> P<ArrayWriteChildren> {
+        P::new(ArrayWriteChildren::new(array, index, value))
     }
 }
 
@@ -77,26 +77,26 @@ impl ArrayWrite {
         checks::expect_concrete_bitvec_ty(&value, array_ty.value_ty())?;
         Ok(ArrayWrite{
             widths: array_ty,
-            childs: ArrayWriteChilds::new_boxed(array, index, value)
+            children: ArrayWriteChildren::new_boxed(array, index, value)
         })
     }
 }
 
-impl Childs for ArrayWriteChilds {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::ternary(&self.array, &self.index, &self.value)
+impl Children for ArrayWriteChildren {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::ternary(&self.array, &self.index, &self.value)
     }
 }
 
-impl ChildsMut for ArrayWriteChilds {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::ternary(&mut self.array, &mut self.index, &mut self.value)
+impl ChildrenMut for ArrayWriteChildren {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::ternary(&mut self.array, &mut self.index, &mut self.value)
     }
 }
 
-impl IntoChilds for ArrayWriteChilds {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::ternary(self.array, self.index, self.value)
+impl IntoChildren for ArrayWriteChildren {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::ternary(self.array, self.index, self.value)
     }
 }
 
@@ -124,20 +124,20 @@ impl From<ArrayWrite> for AnyExpr {
     }
 }
 
-impl Childs for ArrayWrite {
-    fn childs(&self) -> ChildsIter {
-        self.childs.childs()
+impl Children for ArrayWrite {
+    fn children(&self) -> ChildrenIter {
+        self.children.children()
     }
 }
 
-impl ChildsMut for ArrayWrite {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        self.childs.childs_mut()
+impl ChildrenMut for ArrayWrite {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        self.children.children_mut()
     }
 }
 
-impl IntoChilds for ArrayWrite {
-    fn into_childs(self) -> IntoChildsIter {
-        self.childs.into_childs()
+impl IntoChildren for ArrayWrite {
+    fn into_children(self) -> IntoChildrenIter {
+        self.children.into_children()
     }
 }

--- a/src/ast/terms/binexpr.rs
+++ b/src/ast/terms/binexpr.rs
@@ -17,7 +17,7 @@ pub mod prelude {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BinTermExpr<M> {
     /// The two child term expressions.
-    pub childs: P<BinExprChilds>,
+    pub children: P<BinExprChildren>,
     /// The bit width of this expression.
     /// 
     /// All child expressions must respect this bit width.
@@ -43,7 +43,7 @@ impl<M> BinTermExpr<M> {
         let rhs = rhs.into();
         checks::expect_concrete_bitvec_ty(&lhs, bitvec_ty)?;
         checks::expect_concrete_bitvec_ty(&rhs, bitvec_ty)?;
-        Ok(Self{ bitvec_ty, childs: BinExprChilds::new_boxed(lhs, rhs), marker: PhantomData })
+        Ok(Self{ bitvec_ty, children: BinExprChildren::new_boxed(lhs, rhs), marker: PhantomData })
     }
 
     /// Returns a new binary term expression for the two given child term expressions.
@@ -63,25 +63,25 @@ impl<M> BinTermExpr<M> {
         let lhs = lhs.into();
         let rhs = rhs.into();
         let common_ty = checks::expect_common_bitvec_ty(&lhs, &rhs)?;
-        Ok(Self{ bitvec_ty: common_ty, childs: BinExprChilds::new_boxed(lhs, rhs), marker: PhantomData })
+        Ok(Self{ bitvec_ty: common_ty, children: BinExprChildren::new_boxed(lhs, rhs), marker: PhantomData })
     }
 }
 
-impl<M> Childs for BinTermExpr<M> {
-    fn childs(&self) -> ChildsIter {
-        self.childs.childs()
+impl<M> Children for BinTermExpr<M> {
+    fn children(&self) -> ChildrenIter {
+        self.children.children()
     }
 }
 
-impl<M> ChildsMut for BinTermExpr<M> {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        self.childs.childs_mut()
+impl<M> ChildrenMut for BinTermExpr<M> {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        self.children.children_mut()
     }
 }
 
-impl<M> IntoChilds for BinTermExpr<M> {
-    fn into_childs(self) -> IntoChildsIter {
-        self.childs.into_childs()
+impl<M> IntoChildren for BinTermExpr<M> {
+    fn into_children(self) -> IntoChildrenIter {
+        self.children.into_children()
     }
 }
 

--- a/src/ast/terms/bitvec_equals.rs
+++ b/src/ast/terms/bitvec_equals.rs
@@ -22,9 +22,9 @@ pub mod prelude {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BitvecEquals {
     /// The child expressions.
-    pub childs: Vec<AnyExpr>,
+    pub children: Vec<AnyExpr>,
     /// The common bit width of all child bitvec expressions.
-    pub childs_bitvec_ty: BitvecTy
+    pub children_bitvec_ty: BitvecTy
 }
 
 impl BitvecEquals {
@@ -42,14 +42,14 @@ impl BitvecEquals {
         let rhs = rhs.into();
         checks::expect_concrete_bitvec_ty(&rhs, bitvec_ty)?;
         checks::expect_concrete_bitvec_ty(&rhs, bitvec_ty)?;
-        Ok(BitvecEquals{ childs_bitvec_ty: bitvec_ty, childs: vec![lhs, rhs] })
+        Ok(BitvecEquals{ children_bitvec_ty: bitvec_ty, children: vec![lhs, rhs] })
     }
 
     /// Returns a new binary `BitvecEquals` expression for the given two child expressions.
     /// 
     /// # Note
     /// 
-    /// Infers the concrete bitvector type of the resulting expression from its childs.
+    /// Infers the concrete bitvector type of the resulting expression from its children.
     /// 
     /// # Errors
     /// 
@@ -61,7 +61,7 @@ impl BitvecEquals {
         let lhs = lhs.into();
         let rhs = rhs.into();
         let common_ty = checks::expect_common_bitvec_ty(&lhs, &rhs)?;
-        Ok(BitvecEquals{ childs_bitvec_ty: common_ty, childs: vec![lhs, rhs] })
+        Ok(BitvecEquals{ children_bitvec_ty: common_ty, children: vec![lhs, rhs] })
     }
 
     /// Creates a new n-ary `BitvecEquals` expression from the given iterator over expressions.
@@ -73,14 +73,14 @@ impl BitvecEquals {
     pub fn nary_with_type<E>(bitvec_ty: BitvecTy, exprs: E) -> Result<BitvecEquals, String>
         where E: IntoIterator<Item=AnyExpr>
     {
-        let childs = Vec::from_iter(exprs);
-        if childs.len() < 2 {
+        let children = Vec::from_iter(exprs);
+        if children.len() < 2 {
             return Err("Require at least 2 child expressions to create a new BitvecEquals expression.".into())
         }
-        for child in &childs {
+        for child in &children {
             checks::expect_concrete_bitvec_ty(child, bitvec_ty)?;
         }
-        Ok(BitvecEquals{ childs_bitvec_ty: bitvec_ty, childs })
+        Ok(BitvecEquals{ children_bitvec_ty: bitvec_ty, children })
     }
 
     /// Creates a new n-ary `BitvecEquals` expression from the given iterator over expressions.
@@ -94,12 +94,12 @@ impl BitvecEquals {
     pub fn nary<E>(exprs: E) -> Result<BitvecEquals, String>
         where E: IntoIterator<Item=AnyExpr>
     {
-        let childs = exprs.into_iter().collect::<Vec<_>>();
-        if childs.len() < 2 {
+        let children = exprs.into_iter().collect::<Vec<_>>();
+        if children.len() < 2 {
             return Err("Require at least 2 child expressions to create a new BitvecEquals expression.".into())
         }
-        let childs_bitvec_ty = checks::expect_common_bitvec_ty_n(&childs)?;
-        Ok(BitvecEquals{ childs_bitvec_ty, childs })
+        let children_bitvec_ty = checks::expect_common_bitvec_ty_n(&children)?;
+        Ok(BitvecEquals{ children_bitvec_ty, children })
     }
 }
 
@@ -117,7 +117,7 @@ impl HasKind for BitvecEquals {
 
 impl HasArity for BitvecEquals {
     fn arity(&self) -> usize {
-        self.childs.len()
+        self.children.len()
     }
 }
 
@@ -127,27 +127,27 @@ impl From<BitvecEquals> for AnyExpr {
     }
 }
 
-impl Childs for BitvecEquals {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::nary(&self.childs)
+impl Children for BitvecEquals {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::nary(&self.children)
     }
 }
 
-impl ChildsMut for BitvecEquals {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::nary(&mut self.childs)
+impl ChildrenMut for BitvecEquals {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::nary(&mut self.children)
     }
 }
 
-impl IntoChilds for BitvecEquals {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::nary(self.childs)
+impl IntoChildren for BitvecEquals {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::nary(self.children)
     }
 }
 
 impl DedupChildren for BitvecEquals {
     fn dedup_children(&mut self) {
-        self.childs.dedup()
+        self.children.dedup()
     }
 }
 
@@ -155,7 +155,7 @@ impl SortChildren for BitvecEquals {
     fn sort_children_by<F>(&mut self, comparator: F)
         where F: FnMut(&AnyExpr, &AnyExpr) -> Ordering
     {
-        self.childs.sort_unstable_by(comparator)
+        self.children.sort_unstable_by(comparator)
     }
 }
 
@@ -163,6 +163,6 @@ impl RetainChildren for BitvecEquals {
     fn retain_children<P>(&mut self, predicate: P)
         where P: FnMut(&AnyExpr) -> bool
     {
-        self.childs.retain(predicate);
+        self.children.retain(predicate);
     }
 }

--- a/src/ast/terms/bitwise/bitnot.rs
+++ b/src/ast/terms/bitwise/bitnot.rs
@@ -51,21 +51,21 @@ impl BitNot {
     }
 }
 
-impl Childs for BitNot {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::unary(&self.child)
+impl Children for BitNot {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::unary(&self.child)
     }
 }
 
-impl ChildsMut for BitNot {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::unary(&mut self.child)
+impl ChildrenMut for BitNot {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::unary(&mut self.child)
     }
 }
 
-impl IntoChilds for BitNot {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::unary(*self.child)
+impl IntoChildren for BitNot {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::unary(*self.child)
     }
 }
 

--- a/src/ast/terms/cast/concat.rs
+++ b/src/ast/terms/cast/concat.rs
@@ -15,7 +15,7 @@ pub mod prelude {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Concat {
     /// The two child term expressions.
-    pub childs: P<BinExprChilds>,
+    pub children: P<BinExprChildren>,
     /// The resulting bit width.
     /// 
     /// The purpose of this is to cache the bitwidth so that
@@ -45,26 +45,26 @@ impl Concat {
             lhs_bvty.width().to_usize() + rhs_bvty.width().to_usize());
         Ok(Concat{
             bitvec_ty: concat_bvty,
-            childs: BinExprChilds::new_boxed(lhs, rhs)
+            children: BinExprChildren::new_boxed(lhs, rhs)
         })
     }
 }
 
-impl Childs for Concat {
-    fn childs(&self) -> ChildsIter {
-        self.childs.childs()
+impl Children for Concat {
+    fn children(&self) -> ChildrenIter {
+        self.children.children()
     }
 }
 
-impl ChildsMut for Concat {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        self.childs.childs_mut()
+impl ChildrenMut for Concat {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        self.children.children_mut()
     }
 }
 
-impl IntoChilds for Concat {
-    fn into_childs(self) -> IntoChildsIter {
-        self.childs.into_childs()
+impl IntoChildren for Concat {
+    fn into_children(self) -> IntoChildrenIter {
+        self.children.into_children()
     }
 }
 

--- a/src/ast/terms/cast/extend.rs
+++ b/src/ast/terms/cast/extend.rs
@@ -51,21 +51,21 @@ impl<M> ExtendExpr<M> {
     }
 }
 
-impl<M> Childs for ExtendExpr<M> {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::unary(&self.src)
+impl<M> Children for ExtendExpr<M> {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::unary(&self.src)
     }
 }
 
-impl<M> ChildsMut for ExtendExpr<M> {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::unary(&mut self.src)
+impl<M> ChildrenMut for ExtendExpr<M> {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::unary(&mut self.src)
     }
 }
 
-impl<M> IntoChilds for ExtendExpr<M> {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::unary(*self.src)
+impl<M> IntoChildren for ExtendExpr<M> {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::unary(*self.src)
     }
 }
 

--- a/src/ast/terms/cast/extract.rs
+++ b/src/ast/terms/cast/extract.rs
@@ -54,21 +54,21 @@ impl Extract {
     }
 }
 
-impl Childs for Extract {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::unary(&self.src)
+impl Children for Extract {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::unary(&self.src)
     }
 }
 
-impl ChildsMut for Extract {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::unary(&mut self.src)
+impl ChildrenMut for Extract {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::unary(&mut self.src)
     }
 }
 
-impl IntoChilds for Extract {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::unary(*self.src)
+impl IntoChildren for Extract {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::unary(*self.src)
     }
 }
 

--- a/src/ast/terms/cmp_expr.rs
+++ b/src/ast/terms/cmp_expr.rs
@@ -25,12 +25,12 @@ pub mod prelude {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ComparisonExpr<M> {
     /// The two child term expressions.
-    pub childs: P<BinExprChilds>,
+    pub children: P<BinExprChildren>,
     /// The bit width of this expression.
     /// 
     /// All child expressions must respect this bit width.
     /// This is also used to verify integrity of the bit width.
-    pub childs_bitvec_ty: BitvecTy,
+    pub children_bitvec_ty: BitvecTy,
     /// Marker to differentiate bool expressions from each
     /// other using the type system.
     marker: PhantomData<M>
@@ -51,14 +51,14 @@ impl<M> ComparisonExpr<M> {
         let rhs = rhs.into();
         checks::expect_concrete_bitvec_ty(&lhs, bitvec_ty)?;
         checks::expect_concrete_bitvec_ty(&rhs, bitvec_ty)?;
-        Ok(Self{ childs_bitvec_ty: bitvec_ty, childs: BinExprChilds::new_boxed(lhs, rhs), marker: PhantomData })
+        Ok(Self{ children_bitvec_ty: bitvec_ty, children: BinExprChildren::new_boxed(lhs, rhs), marker: PhantomData })
     }
 
     /// Returns a new comparison expression for the given two child expressions.
     /// 
     /// # Note
     /// 
-    /// Infers the concrete bitvector type of the resulting expression from its childs.
+    /// Infers the concrete bitvector type of the resulting expression from its children.
     /// 
     /// # Errors
     /// 
@@ -70,7 +70,7 @@ impl<M> ComparisonExpr<M> {
         let lhs = lhs.into();
         let rhs = rhs.into();
         let common_ty = checks::expect_common_bitvec_ty(&lhs, &rhs)?;
-        Ok(Self{ childs_bitvec_ty: common_ty, childs: BinExprChilds::new_boxed(lhs, rhs), marker: PhantomData })
+        Ok(Self{ children_bitvec_ty: common_ty, children: BinExprChildren::new_boxed(lhs, rhs), marker: PhantomData })
     }
 
     /// Creates a new comparison expression from the given raw parts.
@@ -80,8 +80,8 @@ impl<M> ComparisonExpr<M> {
     /// This is unsafe since it does not check the type requirements for the given child expressions
     /// thus allowing users of this API to break invariants of this type which could ultimatively
     /// lead to undefined behaviour indirectly in code depending on those invariants.
-    pub unsafe fn new_unchecked(bitvec_ty: BitvecTy, childs: P<BinExprChilds>) -> Self {
-        Self{childs_bitvec_ty: bitvec_ty, childs, marker: PhantomData}
+    pub unsafe fn new_unchecked(bitvec_ty: BitvecTy, children: P<BinExprChildren>) -> Self {
+        Self{children_bitvec_ty: bitvec_ty, children, marker: PhantomData}
     }
 }
 
@@ -89,21 +89,21 @@ impl<M> BoolExpr for ComparisonExpr<M>
     where Self: Into<AnyExpr>
 {}
 
-impl<M> Childs for ComparisonExpr<M> {
-    fn childs(&self) -> ChildsIter {
-        self.childs.childs()
+impl<M> Children for ComparisonExpr<M> {
+    fn children(&self) -> ChildrenIter {
+        self.children.children()
     }
 }
 
-impl<M> ChildsMut for ComparisonExpr<M> {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        self.childs.childs_mut()
+impl<M> ChildrenMut for ComparisonExpr<M> {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        self.children.children_mut()
     }
 }
 
-impl<M> IntoChilds for ComparisonExpr<M> {
-    fn into_childs(self) -> IntoChildsIter {
-        self.childs.into_childs()
+impl<M> IntoChildren for ComparisonExpr<M> {
+    fn into_children(self) -> IntoChildrenIter {
+        self.children.into_children()
     }
 }
 

--- a/src/ast/terms/nary_expr.rs
+++ b/src/ast/terms/nary_expr.rs
@@ -16,7 +16,7 @@ pub mod prelude {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NaryTermExpr<M> {
     /// The child term expressions.
-    pub childs: Vec<AnyExpr>,
+    pub children: Vec<AnyExpr>,
     /// The bit width of this expression.
     ///
     /// All child expressions must respect this bit width.
@@ -47,14 +47,14 @@ impl<M> NaryTermExpr<M> {
         let rhs = rhs.into();
         checks::expect_concrete_bitvec_ty(&lhs, bitvec_ty)?;
         checks::expect_concrete_bitvec_ty(&rhs, bitvec_ty)?;
-        Ok(Self{ bitvec_ty, childs: vec![lhs, rhs], marker: PhantomData })
+        Ok(Self{ bitvec_ty, children: vec![lhs, rhs], marker: PhantomData })
     }
 
     /// Returns a new n-ary term expression for the given two child expressions.
     /// 
     /// # Note
     /// 
-    /// - Infers the concrete bitvector type of the resulting expression from its childs.
+    /// - Infers the concrete bitvector type of the resulting expression from its children.
     /// - Since the given two child expressions are the child expressions of the resulting
     ///   n-ary term expression it will actually be a binary term expression upon construction.
     /// 
@@ -68,7 +68,7 @@ impl<M> NaryTermExpr<M> {
         let lhs = lhs.into();
         let rhs = rhs.into();
         let common_ty = checks::expect_common_bitvec_ty(&lhs, &rhs)?;
-        Ok(Self{ bitvec_ty: common_ty, childs: vec![lhs, rhs], marker: PhantomData })
+        Ok(Self{ bitvec_ty: common_ty, children: vec![lhs, rhs], marker: PhantomData })
     }
 
     /// Creates a new n-ary term expression for all of the child
@@ -79,16 +79,16 @@ impl<M> NaryTermExpr<M> {
     /// - If the given iterator yields less than two child expressions.
     /// - If not all yielded child expressions are of bitvec type with
     ///   the required bit width.
-    pub fn nary_with_type<I>(bitvec_ty: BitvecTy, childs: I) -> Result<Self, String>
+    pub fn nary_with_type<I>(bitvec_ty: BitvecTy, children: I) -> Result<Self, String>
         where I: IntoIterator<Item = AnyExpr>,
     {
-        let childs = childs.into_iter().collect::<Vec<_>>();
-        if childs.len() < 2 {
+        let children = children.into_iter().collect::<Vec<_>>();
+        if children.len() < 2 {
             return Err(
                 "Requires at least two child expressions to create an n-ary term expression.".into(),
             );
         }
-        if childs
+        if children
             .iter()
             .any(|c| checks::expect_concrete_bitvec_ty(c, bitvec_ty).is_err())
         {
@@ -97,7 +97,7 @@ impl<M> NaryTermExpr<M> {
                     .into(),
             );
         }
-        Ok(Self{ bitvec_ty, childs, marker: PhantomData })
+        Ok(Self{ bitvec_ty, children, marker: PhantomData })
     }
 
     /// Creates a new n-ary term expression from the given iterator over expressions.
@@ -113,30 +113,30 @@ impl<M> NaryTermExpr<M> {
     pub fn nary<E>(exprs: E) -> Result<Self, String>
         where E: IntoIterator<Item=AnyExpr>
     {
-        let childs = exprs.into_iter().collect::<Vec<_>>();
-        if childs.len() < 2 {
+        let children = exprs.into_iter().collect::<Vec<_>>();
+        if children.len() < 2 {
             return Err("Require at least 2 child expressions to create a new n-ary term expression.".into())
         }
-        let bitvec_ty = checks::expect_common_bitvec_ty_n(&childs)?;
-        Ok(Self{ bitvec_ty, childs, marker: PhantomData })
+        let bitvec_ty = checks::expect_common_bitvec_ty_n(&children)?;
+        Ok(Self{ bitvec_ty, children, marker: PhantomData })
     }
 }
 
-impl<M> Childs for NaryTermExpr<M> {
-    fn childs(&self) -> ChildsIter {
-        ChildsIter::nary(&self.childs)
+impl<M> Children for NaryTermExpr<M> {
+    fn children(&self) -> ChildrenIter {
+        ChildrenIter::nary(&self.children)
     }
 }
 
-impl<M> ChildsMut for NaryTermExpr<M> {
-    fn childs_mut(&mut self) -> ChildsIterMut {
-        ChildsIterMut::nary(&mut self.childs)
+impl<M> ChildrenMut for NaryTermExpr<M> {
+    fn children_mut(&mut self) -> ChildrenIterMut {
+        ChildrenIterMut::nary(&mut self.children)
     }
 }
 
-impl<M> IntoChilds for NaryTermExpr<M> {
-    fn into_childs(self) -> IntoChildsIter {
-        IntoChildsIter::nary(self.childs)
+impl<M> IntoChildren for NaryTermExpr<M> {
+    fn into_children(self) -> IntoChildrenIter {
+        IntoChildrenIter::nary(self.children)
     }
 }
 
@@ -156,13 +156,13 @@ impl<M> HasKind for NaryTermExpr<M>
 
 impl<M> HasArity for NaryTermExpr<M> {
     fn arity(&self) -> usize {
-        self.childs.len()
+        self.children.len()
     }
 }
 
 impl<M> DedupChildren for NaryTermExpr<M> {
     fn dedup_children(&mut self) {
-        self.childs.dedup()
+        self.children.dedup()
     }
 }
 
@@ -170,7 +170,7 @@ impl<M> SortChildren for NaryTermExpr<M> {
     fn sort_children_by<F>(&mut self, comparator: F)
         where F: FnMut(&AnyExpr, &AnyExpr) -> Ordering
     {
-        self.childs.sort_unstable_by(comparator)
+        self.children.sort_unstable_by(comparator)
     }
 }
 
@@ -178,6 +178,6 @@ impl<M> RetainChildren for NaryTermExpr<M> {
     fn retain_children<P>(&mut self, predicate: P)
         where P: FnMut(&AnyExpr) -> bool
     {
-        self.childs.retain(predicate);
+        self.children.retain(predicate);
     }
 }

--- a/src/ast/transformer.rs
+++ b/src/ast/transformer.rs
@@ -339,7 +339,7 @@ impl<T> TraverseTransformer<T>
         let mut result = TransformEffect::Identity;
         // Transform the current expression before all of its children.
         result |= self.transformer.transform_any_expr(expr);
-        for child in expr.childs_mut() {
+        for child in expr.children_mut() {
             result |= self.traverse_transform(child);
         }
         // Transform the current expression again after all of its children.

--- a/src/simplifier/simplifications/bool_lowering.rs
+++ b/src/simplifier/simplifications/bool_lowering.rs
@@ -12,7 +12,7 @@ impl AutoImplAnyTransformer for BoolReducer {}
 
 impl Transformer for BoolReducer {
     fn transform_implies(&self, implies: expr::Implies) -> TransformOutcome {
-        let (lhs, rhs) = implies.childs.into_children_pair();
+        let (lhs, rhs) = implies.children.into_children_pair();
         TransformOutcome::transformed(
             expr::Or::binary(expr::Not::new(lhs).unwrap(), rhs).unwrap()
         )

--- a/src/simplifier/simplifications/bool_symbolic_solver.rs
+++ b/src/simplifier/simplifications/bool_symbolic_solver.rs
@@ -31,12 +31,12 @@ impl Transformer for BoolSymbolicSolver {
         // If then and else cases are equal we can lower the entire if-then-else
         // to either one. The condition can be dropped since it has no effect to
         // the result. We simply lower to the then-case in this situation.
-        if ite.childs.then_case == ite.childs.else_case {
-            return TransformOutcome::transformed(ite.childs.then_case)
+        if ite.children.then_case == ite.children.else_case {
+            return TransformOutcome::transformed(ite.children.then_case)
         }
         // If the condition is a logical-negation we can drop the negation by
         // swapping the then and else case.
-        if let box IfThenElseChilds{ cond: AnyExpr::Not(not), then_case, else_case } = ite.childs {
+        if let box IfThenElseChildren{ cond: AnyExpr::Not(not), then_case, else_case } = ite.children {
             return TransformOutcome::transformed(unsafe{
                 expr::IfThenElse::new_unchecked(
                     not.into_single_child(),
@@ -51,8 +51,8 @@ impl Transformer for BoolSymbolicSolver {
     fn transform_bool_equals(&self, bool_equals: expr::BoolEquals) -> TransformOutcome {
         // If there exists any pair that logically contradicts each other
         // then this is always false.
-        if bool_equals.childs()
-                      .cartesian_product(bool_equals.childs())
+        if bool_equals.children()
+                      .cartesian_product(bool_equals.children())
                       .any(|(lhs, rhs)| is_logical_contradiction(lhs, rhs))
         {
             return TransformOutcome::transformed(expr::BoolConst::from(false))
@@ -63,8 +63,8 @@ impl Transformer for BoolSymbolicSolver {
     fn transform_and(&self, and: expr::And) -> TransformOutcome {
         // If there exists any pair that logically contradicts each other
         // then this is always false.
-        if and.childs()
-              .cartesian_product(and.childs())
+        if and.children()
+              .cartesian_product(and.children())
               .any(|(lhs, rhs)| is_logical_contradiction(lhs, rhs))
         {
             return TransformOutcome::transformed(expr::BoolConst::from(false))
@@ -75,8 +75,8 @@ impl Transformer for BoolSymbolicSolver {
     fn transform_or(&self, or: expr::Or) -> TransformOutcome {
         // If there exists any pair that logically contradicts each other
         // then this is always true.
-        if or.childs()
-             .cartesian_product(or.childs())
+        if or.children()
+             .cartesian_product(or.children())
              .any(|(lhs, rhs)| is_logical_contradiction(lhs, rhs))
         {
             return TransformOutcome::transformed(expr::BoolConst::from(true))
@@ -86,11 +86,11 @@ impl Transformer for BoolSymbolicSolver {
 
     fn transform_xor(&self, xor: expr::Xor) -> TransformOutcome {
         // If both child expressions are equal this is always false.
-        if xor.childs.lhs == xor.childs.rhs {
+        if xor.children.lhs == xor.children.rhs {
             return TransformOutcome::transformed(expr::BoolConst::from(false))
         }
         // If both child expressions form a logical contradiction this is always true.
-        if is_logical_contradiction(&xor.childs.lhs, &xor.childs.rhs) {
+        if is_logical_contradiction(&xor.children.lhs, &xor.children.rhs) {
             return TransformOutcome::transformed(expr::BoolConst::from(true))
         }
         TransformOutcome::identity(xor)
@@ -98,7 +98,7 @@ impl Transformer for BoolSymbolicSolver {
 
     fn transform_implies(&self, implies: expr::Implies) -> TransformOutcome {
         // If both child expressions are equal this is true.
-        if implies.childs.lhs == implies.childs.rhs {
+        if implies.children.lhs == implies.children.rhs {
             return TransformOutcome::transformed(expr::BoolConst::from(true))
         }
         // If both child expressions form a logical contradiction this is
@@ -106,8 +106,8 @@ impl Transformer for BoolSymbolicSolver {
         // 
         // *  not(a) =>     a   -->      a
         // *      a  => not(a)  -->  not(a)
-        if is_logical_contradiction(&implies.childs.lhs, &implies.childs.rhs) {
-            return TransformOutcome::transformed(implies.childs.rhs)
+        if is_logical_contradiction(&implies.children.lhs, &implies.children.rhs) {
+            return TransformOutcome::transformed(implies.children.rhs)
         }
         TransformOutcome::identity(implies)
     }

--- a/src/simplifier/simplifications/cmp_reduction.rs
+++ b/src/simplifier/simplifications/cmp_reduction.rs
@@ -8,40 +8,40 @@ pub mod prelude {
 
 /// Reduces this `SignedGreaterEquals` to using less-than as only comparison.
 fn reduce_sge_to_slt(sge: expr::SignedGreaterEquals) -> expr::Not {
-    unsafe{ expr::SignedLessThan::new_unchecked(sge.childs_bitvec_ty, sge.childs) }.wrap_with_not()
+    unsafe{ expr::SignedLessThan::new_unchecked(sge.children_bitvec_ty, sge.children) }.wrap_with_not()
 }
 
 /// Reduces this `SignedLessThan` to using less-than as only comparison.
 fn reduce_sgt_to_slt(sgt: expr::SignedGreaterThan) -> expr::SignedLessThan {
     let mut sgt = sgt;
-    sgt.childs.swap_childs();
-    unsafe{ expr::SignedLessThan::new_unchecked(sgt.childs_bitvec_ty, sgt.childs) }
+    sgt.children.swap_children();
+    unsafe{ expr::SignedLessThan::new_unchecked(sgt.children_bitvec_ty, sgt.children) }
 }
 
 /// Creates a new `SignedLessEquals` expression from the given `SignedGreaterThan`.
 fn reduce_sle_to_slt(sle: expr::SignedLessEquals) -> expr::Not {
     let mut sle = sle;
-    sle.childs.swap_childs();
-    unsafe{ expr::SignedLessThan::new_unchecked(sle.childs_bitvec_ty, sle.childs).wrap_with_not() }
+    sle.children.swap_children();
+    unsafe{ expr::SignedLessThan::new_unchecked(sle.children_bitvec_ty, sle.children).wrap_with_not() }
 }
 
 /// Reduces this `UnsignedGreaterEquals` to using less-than as only comparison.
 fn reduce_uge_to_ult(uge: expr::UnsignedGreaterEquals) -> expr::Not {
-    unsafe{ expr::UnsignedLessThan::new_unchecked(uge.childs_bitvec_ty, uge.childs) }.wrap_with_not()
+    unsafe{ expr::UnsignedLessThan::new_unchecked(uge.children_bitvec_ty, uge.children) }.wrap_with_not()
 }
 
 /// Reduces this `UnsignedLessThan` to using less-than as only comparison.
 fn reduce_ugt_to_ult(ugt: expr::UnsignedGreaterThan) -> expr::UnsignedLessThan {
     let mut ugt = ugt;
-    ugt.childs.swap_childs();
-    unsafe{ expr::UnsignedLessThan::new_unchecked(ugt.childs_bitvec_ty, ugt.childs) }
+    ugt.children.swap_children();
+    unsafe{ expr::UnsignedLessThan::new_unchecked(ugt.children_bitvec_ty, ugt.children) }
 }
 
 /// Creates a new `UnsignedLessEquals` expression from the given `SignedGreaterThan`.
 fn reduce_ule_to_ult(ule: expr::UnsignedLessEquals) -> expr::Not {
     let mut ule = ule;
-    ule.childs.swap_childs();
-    unsafe{ expr::UnsignedLessThan::new_unchecked(ule.childs_bitvec_ty, ule.childs).wrap_with_not() }
+    ule.children.swap_children();
+    unsafe{ expr::UnsignedLessThan::new_unchecked(ule.children_bitvec_ty, ule.children).wrap_with_not() }
 }
 
 /// Reduces comparison expressions to less-than forms.

--- a/src/simplifier/simplifications/flattening.rs
+++ b/src/simplifier/simplifications/flattening.rs
@@ -30,11 +30,11 @@ impl AutoImplAnyTransformer for Flattener {}
 macro_rules! flattening_impl_for {
     ($varname:ident: $typename:ident) => {{
         // Do nothing if there exists no child expression with equal kind.
-        if $varname.childs().all(|c| c.kind() != ExprKind::$typename) {
+        if $varname.children().all(|c| c.kind() != ExprKind::$typename) {
             return TransformOutcome::identity($varname);
         }
         // There exist at least one child that can be flattened.
-        let (sames, mut rest): (Vec<_>, Vec<_>) = $varname.into_childs().partition_map(|c| {
+        let (sames, mut rest): (Vec<_>, Vec<_>) = $varname.into_children().partition_map(|c| {
             match c {
                 AnyExpr::$typename(same) => Either::Left(same),
                 other                    => Either::Right(other)
@@ -42,7 +42,7 @@ macro_rules! flattening_impl_for {
         });
         assert!(sames.len() > 0);
         for same in sames {
-            rest.extend(same.into_childs());
+            rest.extend(same.into_children());
         }
         let result = expr::$typename::nary(rest).unwrap();
         TransformOutcome::transformed(result)

--- a/src/simplifier/simplifications/involution.rs
+++ b/src/simplifier/simplifications/involution.rs
@@ -28,7 +28,7 @@ impl Transformer for InvolutionSimplifier {
         if let box AnyExpr::And(and) = not.child {
             return TransformOutcome::transformed(
                 expr::Or::nary(
-                    and.into_childs()
+                    and.into_children()
                        .map(|c| expr::Not::new(c).unwrap())
                        .map(AnyExpr::from))
                        .unwrap()
@@ -38,7 +38,7 @@ impl Transformer for InvolutionSimplifier {
         if let box AnyExpr::Or(or) = not.child {
             return TransformOutcome::transformed(
                 expr::And::nary(
-                    or.into_childs()
+                    or.into_children()
                       .map(|c| expr::Not::new(c).unwrap())
                       .map(AnyExpr::from))
                       .unwrap()
@@ -56,7 +56,7 @@ impl Transformer for InvolutionSimplifier {
         if let box AnyExpr::Add(add) = neg.child {
             return TransformOutcome::transformed(
                 expr::Add::nary(
-                    add.into_childs()
+                    add.into_children()
                       .map(|c| expr::Neg::new(c).unwrap())
                       .map(AnyExpr::from))
                       .unwrap()
@@ -64,7 +64,7 @@ impl Transformer for InvolutionSimplifier {
         }
         // For negated mul we can push an extra `(-1)` child expression: `(neg (mul a b))` -> `(mul a b (-1))`
         if let box AnyExpr::Mul(mut mul) = neg.child {
-            mul.childs.push(
+            mul.children.push(
                 expr::BitvecConst::all_set(mul.bitvec_ty).into()
             );
             return TransformOutcome::transformed(mul)

--- a/src/simplifier/simplifications/normalizer.rs
+++ b/src/simplifier/simplifications/normalizer.rs
@@ -67,7 +67,7 @@ fn normalization_cmp(lhs: &AnyExpr, rhs: &AnyExpr) -> Ordering {
                 Ordering::Less    => Ordering::Less,
                 Ordering::Greater => Ordering::Greater,
                 Ordering::Equal   => {
-                    for (lchild, rchild) in lhs.childs().zip(rhs.childs()) {
+                    for (lchild, rchild) in lhs.children().zip(rhs.children()) {
                         match normalization_cmp(lchild, rchild) {
                             Ordering::Less    => return Ordering::Less,
                             Ordering::Greater => return Ordering::Greater,
@@ -92,10 +92,10 @@ enum NormalizeFlag {
     Success
 }
 
-fn is_sorted_norm<'c, C>(childs: C) -> bool
+fn is_sorted_norm<'c, C>(children: C) -> bool
     where C: IntoIterator<Item=&'c AnyExpr> + 'c
 {
-    childs.into_iter()
+    children.into_iter()
           .tuple_windows()
           .all(|(lhs, rhs)| {
               let order = normalization_cmp(lhs, rhs);
@@ -104,13 +104,13 @@ fn is_sorted_norm<'c, C>(childs: C) -> bool
 }
 
 fn establish_ordering<E>(expr: &mut E) -> NormalizeFlag
-    where E: Childs + SortChildren
+    where E: Children + SortChildren
 {
-    if is_sorted_norm(expr.childs()) {
+    if is_sorted_norm(expr.children()) {
         return NormalizeFlag::Idle
     }
     expr.sort_children_by(normalization_cmp);
-    // expr.childs_vec_mut()
+    // expr.children_vec_mut()
     //     .sort_unstable_by(normalization_cmp);
     NormalizeFlag::Success
 }
@@ -119,7 +119,7 @@ fn remove_duplicates<E>(expr: &mut E) -> NormalizeFlag
     where E: DedupChildren + HasArity
 {
     let arity_before = expr.arity();
-    // expr.childs_vec_mut().dedup();
+    // expr.children_vec_mut().dedup();
     expr.dedup_children();
     let arity_after = expr.arity();
     assert!(arity_after <= arity_before);
@@ -157,7 +157,7 @@ impl NormalizeOutcome {
 }
 
 fn into_normalize<E>(expr: E) -> NormalizeOutcome
-    where E: Childs + DedupChildren + SortChildren + HasArity + Into<AnyExpr>
+    where E: Children + DedupChildren + SortChildren + HasArity + Into<AnyExpr>
 {
     let mut expr = expr;
     let ordering = establish_ordering(&mut expr);
@@ -169,7 +169,7 @@ fn into_normalize<E>(expr: E) -> NormalizeOutcome
     match expr.arity() {
         0 => unreachable!(),
         1 => NormalizeOutcome::DedupToSingle(
-                expr.into().into_childs().next().unwrap()),
+                expr.into().into_children().next().unwrap()),
         _ => NormalizeOutcome::DedupToMany(expr.into())
     }
 }

--- a/src/simplifier/simplifications/term_lowering.rs
+++ b/src/simplifier/simplifications/term_lowering.rs
@@ -12,7 +12,7 @@ impl AutoImplAnyTransformer for TermReducer {}
 
 impl Transformer for TermReducer {
     fn transform_sub(&self, sub: expr::Sub) -> TransformOutcome {
-        let (lhs, rhs) = sub.childs.into_children_pair();
+        let (lhs, rhs) = sub.children.into_children_pair();
         TransformOutcome::transformed(
             expr::Add::binary(lhs, expr::Neg::new(rhs).unwrap()).unwrap()
         )


### PR DESCRIPTION
Modified programmatically using 

`find -type f -iname '*.rs' -print|while read file; do sed -i 's/Childs/Children/g' $file done`
and 
`find -type f -iname '*.rs' -print|while read file; do sed -i 's/childs/children/g' $file done`

